### PR TITLE
Manifest and Collection in site navigation as options

### DIFF
--- a/repos/iiif-storage/config/service.config.php
+++ b/repos/iiif-storage/config/service.config.php
@@ -387,4 +387,10 @@ return [
             },
         ],
     ],
+    'navigation_links' => [
+        'invokables' => [
+            'manifest' => \IIIFStorage\Link\ManifestLink::class,
+            'collection' => \IIIFStorage\Link\CollectionLink::class,
+        ],
+    ],
 ];

--- a/repos/iiif-storage/src/Link/CollectionLink.php
+++ b/repos/iiif-storage/src/Link/CollectionLink.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace IIIFStorage\Link;
+
+use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Site\Navigation\Link\LinkInterface;
+use Omeka\Stdlib\ErrorStore;
+
+class CollectionLink implements LinkInterface
+{
+
+    public function getName()
+    {
+        return 'Collection';
+    }
+
+    public function getFormTemplate()
+    {
+        return 'iiif-storage/link/collection';
+    }
+
+    public function isValid(array $data, ErrorStore $errorStore)
+    {
+        return true;
+    }
+
+    public function getLabel(array $data, SiteRepresentation $site)
+    {
+        return $data['label'] ?? '';
+    }
+
+    public function toZend(array $data, SiteRepresentation $site)
+    {
+        return [
+            'route' => 'site/iiif-collection/view',
+            'params' => [
+                'site-slug' => $site->slug(),
+                'collection' => $data['id'],
+            ],
+        ];
+    }
+
+    public function toJstree(array $data, SiteRepresentation $site)
+    {
+        return [
+            'label' => $data['label'] ?? '',
+            'id' => $data['id'] ?? '',
+        ];
+    }
+}

--- a/repos/iiif-storage/src/Link/ManifestLink.php
+++ b/repos/iiif-storage/src/Link/ManifestLink.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace IIIFStorage\Link;
+
+use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Site\Navigation\Link\LinkInterface;
+use Omeka\Stdlib\ErrorStore;
+
+class ManifestLink implements LinkInterface
+{
+
+    public function getName()
+    {
+        return 'Manifest';
+    }
+
+    public function getFormTemplate()
+    {
+        return 'iiif-storage/link/manifest';
+    }
+
+    public function isValid(array $data, ErrorStore $errorStore)
+    {
+        return true;
+    }
+
+    public function getLabel(array $data, SiteRepresentation $site)
+    {
+        return $data['label'] ?? '';
+    }
+
+    public function toZend(array $data, SiteRepresentation $site)
+    {
+        return [
+            'route' => 'site/iiif-manifest/view',
+            'params' => [
+                'site-slug' => $site->slug(),
+                'manifest' => $data['id'],
+            ],
+        ];
+    }
+
+    public function toJstree(array $data, SiteRepresentation $site)
+    {
+        return [
+          'label' => $data['label'] ?? '',
+            'id' => $data['id'] ?? '',
+        ];
+    }
+}

--- a/repos/iiif-storage/view/iiif-storage/link/collection.phtml
+++ b/repos/iiif-storage/view/iiif-storage/link/collection.phtml
@@ -1,0 +1,32 @@
+<?php
+$escape = $this->plugin('escapeHtml');
+
+/** @var \Omeka\Api\Representation\SiteRepresentation $site */
+$pages = $site->pages();
+
+// Disclaimer, this is nasty.
+$container = $site->getServiceLocator();
+/** @var \IIIFStorage\Repository\CollectionRepository $collection */
+$collection = $container->get(\IIIFStorage\Repository\CollectionRepository::class);
+
+$collectionList = $collection->getAll();
+
+$id = isset($data['id']) && '' !== trim($data['id']) ? $data['id'] : null;
+$label = isset($data['label']) && '' !== trim($data['label']) ? $data['label'] : null;
+
+?>
+<label>
+    Label to show
+    <input type="text" data-name="label" value="<?php echo $label; ?>"/>
+</label>
+<label>
+    Collection to link to
+    <select data-name="id">
+        <?php foreach ($collectionList as $collectionItem): ?>
+            <?php /** @var \Omeka\Api\Representation\ItemRepresentation $collectionItem */ ?>
+            <option value="<?php echo $collectionItem->id(); ?>" <?php if ($id === (string)$collectionItem->id()): ?>selected="selected"<?php endif; ?>>
+                <?php echo $collectionItem->displayTitle(); ?>
+            </option>
+        <?php endforeach; ?>
+    </select>
+</label>

--- a/repos/iiif-storage/view/iiif-storage/link/manifest.phtml
+++ b/repos/iiif-storage/view/iiif-storage/link/manifest.phtml
@@ -1,0 +1,32 @@
+<?php
+$escape = $this->plugin('escapeHtml');
+
+/** @var \Omeka\Api\Representation\SiteRepresentation $site */
+$pages = $site->pages();
+
+// Disclaimer, this is nasty.
+$container = $site->getServiceLocator();
+/** @var \IIIFStorage\Repository\ManifestRepository $manifest */
+$manifest = $container->get(\IIIFStorage\Repository\ManifestRepository::class);
+
+$manifestList = $manifest->getAll();
+
+$id = isset($data['id']) && '' !== trim($data['id']) ? $data['id'] : null;
+$label = isset($data['label']) && '' !== trim($data['label']) ? $data['label'] : null;
+
+?>
+<label>
+    Label to show
+    <input type="text" data-name="label" value="<?php echo $label; ?>"/>
+</label>
+<label>
+    Manifest to link to
+    <select data-name="id">
+        <?php foreach ($manifestList as $manifestItem): ?>
+        <?php /** @var \Omeka\Api\Representation\ItemRepresentation $manifestItem */ ?>
+            <option value="<?php echo $manifestItem->id(); ?>" <?php if ($id === (string)$manifestItem->id()): ?>selected="selected"<?php endif; ?>>
+                <?php echo $manifestItem->displayTitle(); ?>
+            </option>
+        <?php endforeach; ?>
+    </select>
+</label>


### PR DESCRIPTION
Allows you to choose a manifest or a collection, give it a label
and have it show up in the menu, without having to hard-code in
the current site ID or the slug for the manifest or collection.