### PR TITLE
Capture model translate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The internationalisation release.
     - Added attribution to list of IIIF fields imported into Omekas CMS - with importing of different locals
     - IIIF JSON-LD in Omeka will show all available languages in the JSON
     - Replaced build-in omeka HTML media and page block with additional locale setting 
-    - Capture models can now be translated inside of Omeka and will correctly be served depending on your locale
+    - Capture models can now be translated inside of Omeka and will correctly be served depending on your locale (#72)
 - Added files and database volumes to default docker-compose
 - Added new docker compose specifically for running on CI
 - Added new `ci-start` and `ci-stop` commands to madoc cli
@@ -52,6 +52,7 @@ The internationalisation release.
 - Fixed bug where a mis-configured Elucidate may break some pages on the site
 - Fixed issue where multiple HTML page blocks on the same page would not save
 - Fixed bug where you could sync without Transfiex enabled
+- Fixed bug where locale was not being passed to annotation studio (#74)
 
 ## [1.0.1](https://github.com/digirati-co-uk/madoc-platform/compare/v1.0.0...v1.0.1)  - 2019-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The internationalisation release.
     - Added attribution to list of IIIF fields imported into Omekas CMS - with importing of different locals
     - IIIF JSON-LD in Omeka will show all available languages in the JSON
     - Replaced build-in omeka HTML media and page block with additional locale setting 
+    - Capture models can now be translated inside of Omeka and will correctly be served depending on your locale
 - Added files and database volumes to default docker-compose
 - Added new docker compose specifically for running on CI
 - Added new `ci-start` and `ci-stop` commands to madoc cli
@@ -50,6 +51,7 @@ The internationalisation release.
 - Fixed capture model translations in annotation studio module
 - Fixed bug where a mis-configured Elucidate may break some pages on the site
 - Fixed issue where multiple HTML page blocks on the same page would not save
+- Fixed bug where you could sync without Transfiex enabled
 
 ## [1.0.1](https://github.com/digirati-co-uk/madoc-platform/compare/v1.0.0...v1.0.1)  - 2019-03-27
 

--- a/repos/annotation-studio/src/AnnotationStudioFactory.php
+++ b/repos/annotation-studio/src/AnnotationStudioFactory.php
@@ -21,6 +21,7 @@ class AnnotationStudioFactory
     private $canvas;
     private $isLocked;
     private $googleMapApiKey;
+    private $locale;
 
     public function __construct(
         AnnotationStudio $instance,
@@ -151,6 +152,13 @@ class AnnotationStudioFactory
         return $this;
     }
 
+    public function withLocale(string $locale)
+    {
+        $this->locale = $locale;
+
+        return $this;
+    }
+
     public function build(): AnnotationStudio
     {
         $this->instance->addComponent(
@@ -158,7 +166,9 @@ class AnnotationStudioFactory
             new CorePlugin(
                 $this->canvas,
                 $this->manifest,
-                $this->elucidateServer ?? ''
+                $this->elucidateServer ?? '',
+                null,
+                $this->locale
             )
         );
 

--- a/repos/annotation-studio/src/CaptureModel/CaptureModelRepository.php
+++ b/repos/annotation-studio/src/CaptureModel/CaptureModelRepository.php
@@ -6,6 +6,7 @@ use AnnotationStudio\OmekaItemExpander;
 use Omeka\Api\Manager;
 use Omeka\Api\Representation\ItemSetRepresentation;
 use Omeka\Api\Representation\PropertyRepresentation;
+use Omeka\I18n\Translator;
 use Throwable;
 use Zend\EventManager\EventManagerInterface;
 use Zend\I18n\Translator\TranslatorInterface;
@@ -18,7 +19,7 @@ class CaptureModelRepository
      */
     private $api;
     /**
-     * @var TranslatorInterface
+     * @var Translator
      */
     private $translator;
     /**
@@ -33,7 +34,7 @@ class CaptureModelRepository
     public function __construct(
         Manager $api,
         Router $router,
-        TranslatorInterface $translator = null
+        Translator $translator = null
     ) {
         $this->api = $api;
         $this->translator = $translator;

--- a/repos/annotation-studio/src/Components/CorePlugin.php
+++ b/repos/annotation-studio/src/Components/CorePlugin.php
@@ -20,12 +20,16 @@ class CorePlugin implements Component
         Canvas $canvas = null,
         Manifest $manifest = null,
         string $elucidateServer = null,
-        string $target = null
+        string $target = null,
+        string $locale = null
     ) {
         $this->attributes['manifest'] = $manifest->getId();
         $this->attributes['canvas'] = $canvas ? $canvas->getId() : null;
         $this->attributes['elucidate-server'] = $elucidateServer;
         $this->attributes['target'] = $target ? $target : ($canvas ? 'canvas' : 'manifest');
+        if ($locale) {
+            $this->attributes['locale'] = $locale;
+        }
     }
 
     public function __toString()

--- a/repos/annotation-studio/src/OmekaItemExpander.php
+++ b/repos/annotation-studio/src/OmekaItemExpander.php
@@ -71,19 +71,9 @@ class OmekaItemExpander
                     // Can't translate URI.
                     $jsonLd[$key] = $field;
                 } else {
-                    $fallback = $first;
-
-                    foreach ($field as $singleField) {
-                        if ($singleField->lang() === $locale) {
-                            $jsonLd[$key] = self::toJsonValue($singleField, $translator);
-                            break;
-                        }
-                        if (OmekaValue::langMatches($singleField->lang(), $locale)) {
-                            $fallback = self::toJsonValue($singleField, $translator);
-                        }
-                    }
-                    if (!$jsonLd[$key]) {
-                        $jsonLd[$key] = $fallback;
+                    $translatedValue = OmekaValue::translateValue($document, $key, $locale);
+                    if ($translatedValue) {
+                        $jsonLd[$key] = $translatedValue->value();
                     }
                 }
             } else {

--- a/repos/omeka-i18n-module/config/controllers.config.php
+++ b/repos/omeka-i18n-module/config/controllers.config.php
@@ -30,7 +30,12 @@ return [
             },
 
             TranslationSyncController::class => function ($c) {
-                return new TranslationSyncController($c->get('Omeka\JobDispatcher'), $c->get('Omeka\ApiManager'));
+                $config = $c->get('Omeka\Settings');
+                return new TranslationSyncController(
+                    $c->get('Omeka\JobDispatcher'),
+                    $c->get('Omeka\ApiManager'),
+                    boolval($config->get('i18n_transifex-enabled', false))
+                );
             },
 
             LanguageSelectionController::class => function ($c) {

--- a/repos/omeka-i18n-module/src/Controller/TranslationSyncController.php
+++ b/repos/omeka-i18n-module/src/Controller/TranslationSyncController.php
@@ -9,6 +9,7 @@ use Omeka\Job\Dispatcher;
 use Zend\Form\Element\Button;
 use Zend\Form\Element\Hidden;
 use Zend\Form\Form;
+use Zend\Http\Response;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 
@@ -23,11 +24,19 @@ class TranslationSyncController extends AbstractActionController
      * @var Manager
      */
     private $api;
+    /**
+     * @var bool
+     */
+    private $isEnabled;
 
-    public function __construct(Dispatcher $jobDispatcher, Manager $api)
-    {
+    public function __construct(
+        Dispatcher $jobDispatcher,
+        Manager $api,
+        bool $isEnabled
+    ) {
         $this->jobDispatcher = $jobDispatcher;
         $this->api = $api;
+        $this->isEnabled = $isEnabled;
     }
 
     public function showAction()
@@ -40,12 +49,15 @@ class TranslationSyncController extends AbstractActionController
         return (new ViewModel(
             [
                 'form' => $form,
+                'isEnabled' => $this->isEnabled,
             ]
         ))->setTemplate('admin/i18n-synchronize/show');
     }
 
     public function processAction()
     {
+        if (!$this->isEnabled) return null;
+
         $this->jobDispatcher->dispatch(TransifexItemExportJob::class, []);
 
         foreach ($this->api->search('sites')->getContent() as $site) {

--- a/repos/omeka-i18n-module/view/admin/i18n-synchronize/show.twig
+++ b/repos/omeka-i18n-module/view/admin/i18n-synchronize/show.twig
@@ -12,5 +12,5 @@
     {{ formCollection(form, false) }}
     {{ form().closeTag(form) | raw }}
 {% else %}
-    <p>Please enable and configure Transifex to enable sync</p>
+    <p>{{ translate('Please enable and configure Transifex to enable sync.') }}</p>
 {% endif %}

--- a/repos/omeka-i18n-module/view/admin/i18n-synchronize/show.twig
+++ b/repos/omeka-i18n-module/view/admin/i18n-synchronize/show.twig
@@ -3,10 +3,14 @@
 
 {{ pageTitle(translate('Synchronize translations')) }}
 
-{{ form().openTag(form) | raw }}
-<p><b>{{ translate('Are you sure?') }}</b> {{ translate('Clicking Submit will dispatch jobs that will resynchronize localization resources
+{% if isEnabled %}
+    {{ form().openTag(form) | raw }}
+    <p><b>{{ translate('Are you sure?') }}</b> {{ translate('Clicking Submit will dispatch jobs that will resynchronize localization resources
     for all applicable Omeka content.  Synchronization may take some time') }}</p>
-<button type="submit">{{ translate('Submit') }}</button>
+    <button type="submit">{{ translate('Submit') }}</button>
 
-{{ formCollection(form, false) }}
-{{ form().closeTag(form) | raw }}
+    {{ formCollection(form, false) }}
+    {{ form().closeTag(form) | raw }}
+{% else %}
+    <p>Please enable and configure Transifex to enable sync</p>
+{% endif %}

--- a/repos/shared-library/src/Utility/OmekaValue.php
+++ b/repos/shared-library/src/Utility/OmekaValue.php
@@ -48,7 +48,7 @@ class OmekaValue
         }
 
         $values = $representation->values()[$term]['values'];
-        $fallback = $values[0];
+        $fallback = $values[0] ?? null;
 
         foreach ($representation->values()[$term]['values'] as $value) {
             /** @var ValueRepresentation $value */

--- a/translations/madoc/template.pot
+++ b/translations/madoc/template.pot
@@ -90,6 +90,8 @@ msgid "Clicking Submit will dispatch jobs that will resynchronize localization r
 msgstr ""
 msgid "Submit"
 msgstr ""
+msgid "Please enable and configure Transifex to enable sync."
+msgstr ""
 msgid "Back to all groups"
 msgstr ""
 msgid "translations"


### PR DESCRIPTION
## Added
- Capture models can now be translated inside of Omeka and will correctly be served depending on your locale (closes #72)

## Fixed
- Fixed bug where you could sync without Transfiex enabled
- Fixed bug where locale was not being passed to annotation studio (closes #74)