### PR TITLE
[v1.2.0] Search + statistics update

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,6 @@ MYSQL_PORT=3306
 APP_ENV=dev
 MAIN_SITE_DOMAIN=http://localhost:8888/
 ELUCIDATE_URL=madoc-annotation-server:8080
+OMEKA_INTERNAL_URL=http://madoc-platform-omeka/
 ELUCIDATE_PUBLIC_DOMAIN=http://localhost:8888/
+ANNOTATION_INDEXER=http://search-indexer:8000

--- a/.travis/pre-release.sh
+++ b/.travis/pre-release.sh
@@ -6,6 +6,10 @@ NEXT_VERSION=$1;shift;
 # Create short commit hash for tagging.
 COMMIT_HASH="$(git rev-parse --short HEAD)"
 
+echo "Updating dependencies...";
+
+docker pull digirati/madoc-omeka-s:latest
+
 echo "Building v$NEXT_VERSION-$COMMIT_HASH";
 
 # Build.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added manifest statistics subscriber to track statistics
 - Added new Search Omeka module to index created annotations in Elasticsearch
 - Added annotation statistics age block, powered by Elasticsearch
+- Added redirect for single collection sites when viewing entire collection
 
 ### Fixes
 - Fixed bug where canvas ID list may be only a single element
@@ -58,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes contrast issue when marking page as complete (Fixes #111)
 - Fixed mark page as incomplete behaviour
 - Fixed user statistics on profile page
+- Fixed missing translations in Admin site
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed error when duplicate canvases where imported into single manifest
 - Moved media helpers to shared modules
 - Fixed unhandled exception in top contributor page block
+- Fixed bug with checking if canvas inside of manifest
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved media helpers to shared modules
 - Fixed unhandled exception in top contributor page block
 - Fixed bug with checking if canvas inside of manifest
+- Fixes contrast issue when marking page as complete (Fixes #111)
+- 
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unhandled exception in top contributor page block
 - Fixed bug with checking if canvas inside of manifest
 - Fixes contrast issue when marking page as complete (Fixes #111)
-- Fixes mark page as incomplete behaviour
+- Fixed mark page as incomplete behaviour
+- Fixed user statistics on profile page
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unhandled exception in top contributor page block
 - Fixed bug with checking if canvas inside of manifest
 - Fixes contrast issue when marking page as complete (Fixes #111)
-- 
+- Fixes mark page as incomplete behaviour
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added option for semi-public profiles, requiring authentication
 - Added new `HTTP_PROXY` environment variable support for setting HTTP proxy for requesting IIIF resources
 - Added new `HTTP_PROXY_PORT`, `HTTP_PROXY_USER` and `HTTP_PROXY_PASS` environment variables to easily configure an HTTP proxy.
+- Added `OMEKA__INTERNAL_URL` environment variable for internal network requests
+- Added `OMEKA__ANNOTATION_INDEXER` environment variable for annotation indexer service
+- Added `OMEKA__SEARCH_ELASTICSEARCH` environment variable for elasticsearch service
+- Added `OMEKA__ANNOTATION_ES_INDEX` environment variables for annotation indexer service
+- Added `OMEKA__SEARCH_INDEXER` environment variable for search indexer
+- Added elasticsearch to base docker compose
+- Added [https://github.com/digirati-co-uk/jane-founda](Jane Founda) IIIF Search service
+- Added [https://github.com/digirati-co-uk/madoc_draft_indexer](Madoc Indexer) service
+- Added constraints to thumbnail size with customisable import options (1000px max)
+- Added final case for partOf that matches original id
+- Added extra check for manifest when only canvas is provided
+- Added simple statistics module, talking to Elasticsearch
+- Added option for static thumbnail URL
+- Added logging of duplicate Omeka IDs when requesting manifests
+- Added expensive option for resolving Omeka ID from IIIF resource ID
+- Added warning for admin users when they are on a duplicated manifest page
+- Added manifest statistics subscriber to track statistics
+- Added new Search Omeka module to index created annotations in Elasticsearch
+- Added annotation statistics age block, powered by Elasticsearch
 
 ### Fixes
 - Fixed bug where canvas ID list may be only a single element
@@ -28,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed "Got a packet bigger than 'max_allowed_packet' bytes" when adding very large IIIF manifests.
 - Fixed import canvas reference when importing a manifest with previously imported canvases.
 - Fixed IIIF requesting resources not using the HTTP client configuration from Omeka
+- Fixed stale docker images on CI
+- Fixed default locale on Annotation Studio (en)
+- Fixed missing styles for in-progress crowd-sourcing pages
+- Fixed error during import of images with thumbnails (thumbnail image service)
+- Fixed error when duplicate canvases where imported into single manifest
+- Moved media helpers to shared modules
+- Fixed unhandled exception in top contributor page block
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `OMEKA__ANNOTATION_ES_INDEX` environment variables for annotation indexer service
 - Added `OMEKA__SEARCH_INDEXER` environment variable for search indexer
 - Added elasticsearch to base docker compose
-- Added [https://github.com/digirati-co-uk/jane-founda](Jane Founda) IIIF Search service
-- Added [https://github.com/digirati-co-uk/madoc_draft_indexer](Madoc Indexer) service
+- Added [Jane Founda](https://github.com/digirati-co-uk/jane-founda) IIIF Search service
+- Added [Madoc Indexer](https://github.com/digirati-co-uk/madoc_draft_indexer) service
 - Added constraints to thumbnail size with customisable import options (1000px max)
 - Added final case for partOf that matches original id
 - Added extra check for manifest when only canvas is provided

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - OMEKA__ANNOTATION_INDEXER=${ANNOTATION_INDEXER}
       - OMEKA__ELUCIDATE_PUBLIC_DOMAIN=${ELUCIDATE_PUBLIC_DOMAIN}
       - OMEKA__SEARCH_ELASTICSEARCH=search-elasticsearch:9200
+      - OMEKA__ANNOTATION_ES_INDEX=jane-annotations
       - OMEKA__SEARCH_INDEXER=search-indexer:8000
     ports:
       - "8888:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   search-indexer:
     container_name: search-indexer
-    image: digirati/madoc_indexer:a0b59d90bb8ab77d45fc158259bced784259acb8
+    image: digirati/madoc-indexer:a0b59d90bb8ab77d45fc158259bced784259acb8
     environment:
       - WORKERS=2
       - search_annotation_index=jane-annotations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,15 +73,16 @@ services:
       - "discovery.type=single-node"
     ports:
       - 9203:9200
+      - 9204:9201
 
   search-founda:
     image: digirati/jane-founda:d0e7610dc15073e85fce20ee42215e192b16907b
     environment:
       - WORKERS=2
-      - SEARCH_ANNOTATION_INDEX=jane-annotations
-      - SEARCH_ELASTICSEARCH_BASE=search-elasticsearch
-      - SEARCH_ELASTICSEARCH_PORT=9200
-      - SEARCH_SSL_BOOLEAN=false
+      - search_annotation_index=jane-annotations
+      - search_elasticsearch_base=search-elasticsearch
+      - search_elasticsearch_port=9200
+      - search_ssl_boolean=false
     ports:
       - 8103:8000
     links:
@@ -89,13 +90,13 @@ services:
 
   search-indexer:
     container_name: search-indexer
-    image: digirati/madoc_indexer:25dae2e18a6f1fb06f910e21c519fad583ec4ede
+    image: digirati/madoc_indexer:3334192560beb77842ac03bdb681c758419d4a33
     environment:
       - WORKERS=2
-      - SEARCH_ANNOTATION_INDEX=jane-annotations
-      - SEARCH_ELASTICSEARCH_BASE=search-elasticsearch
-      - SEARCH_ELASTICSEARCH_PORT=9200
-      - SEARCH_SSL_BOOLEAN=false
+      - search_annotation_index=jane-annotations
+      - search_elasticsearch_base=search-elasticsearch
+      - search_elasticsearch_port=9200
+      - search_ssl_boolean=false
     ports:
       - 8104:8000
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
   search-indexer:
     container_name: search-indexer
-    image: digirati/madoc_indexer:0d2e60935aa2b2f5de45f1e4d9bfd424af4dc44c
+    image: digirati/madoc_indexer:25dae2e18a6f1fb06f910e21c519fad583ec4ede
     environment:
       - WORKERS=2
       - SEARCH_ANNOTATION_INDEX=jane-annotations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - OMEKA__MAIN_SITE_DOMAIN=${MAIN_SITE_DOMAIN}
       - OMEKA__ELUCIDATE_URL=${ELUCIDATE_URL}
       - OMEKA__ELUCIDATE_PUBLIC_DOMAIN=${ELUCIDATE_PUBLIC_DOMAIN}
+      - OMEKA__SEARCH_ELASTICSEARCH=search-elasticsearch:9200
+      - OMEKA__SEARCH_INDEXER=search-indexer:8000
     ports:
       - "8888:80"
     volumes:
@@ -53,8 +55,47 @@ services:
       - CATALINA_OPTS=-Ddb.url=jdbc:postgresql://database:5432/annotations -Ddb.user="postgres" -Ddb.password=$MYSQL_PASSWORD
     ports:
       - 8889:8080
+
   annotation-database:
     container_name: madoc-annotation-database
     image: "garyttierneydi/elucidate-database:1.4.3-SNAPSHOT"
     environment:
       - POSTGRES_DB=annotations
+
+  search-elasticsearch:
+    container_name: search-elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.2
+    environment:
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "discovery.type=single-node"
+    ports:
+      - 9203:9200
+
+  search-founda:
+    image: digirati/jane-founda:d0e7610dc15073e85fce20ee42215e192b16907b
+    environment:
+      - WORKERS=2
+      - SEARCH_ANNOTATION_INDEX=jane-annotations
+      - SEARCH_ELASTICSEARCH_BASE=search-elasticsearch
+      - SEARCH_ELASTICSEARCH_PORT=9200
+      - SEARCH_SSL_BOOLEAN=false
+    ports:
+      - 8103:8000
+    links:
+      - search-elasticsearch
+
+  search-indexer:
+    container_name: search-indexer
+    image: digirati/madoc_indexer:88aed89770405ffcb5a553aee3bc3475f840cd8c
+    environment:
+      - WORKERS=2
+      - SEARCH_ANNOTATION_INDEX=jane-annotations
+      - SEARCH_ELASTICSEARCH_BASE=search-elasticsearch
+      - SEARCH_ELASTICSEARCH_PORT=9200
+      - SEARCH_SSL_BOOLEAN=false
+    ports:
+      - 8104:8000
+    links:
+      - search-elasticsearch
+      - search-founda

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - OMEKA__DATABASE_PORT=${MYSQL_PORT}
       - OMEKA__MAIN_SITE_DOMAIN=${MAIN_SITE_DOMAIN}
       - OMEKA__ELUCIDATE_URL=${ELUCIDATE_URL}
+      - OMEKA__INTERNAL_URL=${OMEKA_INTERNAL_URL}
+      - OMEKA__ANNOTATION_INDEXER=${ANNOTATION_INDEXER}
       - OMEKA__ELUCIDATE_PUBLIC_DOMAIN=${ELUCIDATE_PUBLIC_DOMAIN}
       - OMEKA__SEARCH_ELASTICSEARCH=search-elasticsearch:9200
       - OMEKA__SEARCH_INDEXER=search-indexer:8000
@@ -90,7 +92,7 @@ services:
 
   search-indexer:
     container_name: search-indexer
-    image: digirati/madoc_indexer:3334192560beb77842ac03bdb681c758419d4a33
+    image: digirati/madoc_indexer:a0b59d90bb8ab77d45fc158259bced784259acb8
     environment:
       - WORKERS=2
       - search_annotation_index=jane-annotations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   search-indexer:
     container_name: search-indexer
-    image: digirati/madoc-indexer:a0b59d90bb8ab77d45fc158259bced784259acb8
+    image: digirati/madoc-indexer:c26e42ad8b8e721d20d254e5214679498868518d
     environment:
       - WORKERS=2
       - search_annotation_index=jane-annotations

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
     environment:
       - DATABASE_USER=postgres
       - CATALINA_OPTS=-Ddb.url=jdbc:postgresql://database:5432/annotations -Ddb.user="postgres" -Ddb.password=$MYSQL_PASSWORD
+      - BASE_HOST=localhost
+      - BASE_PORT=8889
     ports:
       - 8889:8080
 
@@ -87,7 +89,7 @@ services:
 
   search-indexer:
     container_name: search-indexer
-    image: digirati/madoc_indexer:88aed89770405ffcb5a553aee3bc3475f840cd8c
+    image: digirati/madoc_indexer:0d2e60935aa2b2f5de45f1e4d9bfd424af4dc44c
     environment:
       - WORKERS=2
       - SEARCH_ANNOTATION_INDEX=jane-annotations
@@ -97,5 +99,7 @@ services:
     ports:
       - 8104:8000
     links:
+      - omeka-ecosystem
+      - annotation-server
       - search-elasticsearch
       - search-founda

--- a/repos/annotation-studio/src/AnnotationStudioFactory.php
+++ b/repos/annotation-studio/src/AnnotationStudioFactory.php
@@ -20,7 +20,7 @@ class AnnotationStudioFactory
     private $manifest;
     private $canvas;
     private $isLocked;
-    private $locale;
+    private $locale = 'en';
 
     public function __construct(
         AnnotationStudio $instance,
@@ -163,7 +163,7 @@ class AnnotationStudioFactory
 
     public function withLocale(string $locale)
     {
-        $this->locale = $locale;
+        $this->locale = $locale ? $locale : 'en';
 
         return $this;
     }

--- a/repos/iiif-storage/Module.php
+++ b/repos/iiif-storage/Module.php
@@ -196,6 +196,14 @@ class Module extends AbstractModule implements ConfigProviderInterface
                             ])
                             ->setValue($form->getSiteSettings()->get('cs-show-annotations', true))
                     )
+                    ->add(
+                        (new Checkbox('cs-single-collection'))
+                            ->setOptions([
+                                'label' => 'Show single collection', // @translate
+                                'info' => 'By default if there is only one collection, the collection list will redirect to this. This option will disable that behaviour' // @translate
+                            ])
+                            ->setValue($form->getSiteSettings()->get('cs-single-collection', true))
+                    )
                     ->setOptions([
                         'label' => 'Crowd sourcing',
                     ])

--- a/repos/iiif-storage/Module.php
+++ b/repos/iiif-storage/Module.php
@@ -104,53 +104,53 @@ class Module extends AbstractModule implements ConfigProviderInterface
                     ->add(
                         (new Checkbox('collection-manifest-carousel'))
                             ->setOptions([
-                                'label' => 'Use carousel on collection page',
-                                'info' => 'When viewing a collection of manifests, show each manifest as a carousel, instead of a single thumbnail. NOTE: this will request more canvases and may slow down page, consider reducing the manifests per page below.'
+                                'label' => 'Use carousel on collection page', // @translate
+                                'info' => 'When viewing a collection of manifests, show each manifest as a carousel, instead of a single thumbnail. NOTE: this will request more canvases and may slow down page, consider reducing the manifests per page below.'  // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('collection-manifest-carousel', false))
                     )
                     ->add(
                         (new Checkbox('original-ids'))
                             ->setOptions([
-                                'label' => 'Use original IDs',
-                                'info' => 'By default, '
+                                'label' => 'Use original IDs', // @translate
+                                'info' => 'By default, ' // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('original-ids', false))
                     )
                     ->add(
                         (new Text('collections-per-page'))
                             ->setOptions([
-                                'label' => 'Collections per page',
-                                'info' => 'Amount of collections to view on top level collection per page',
+                                'label' => 'Collections per page', // @translate
+                                'info' => 'Amount of collections to view on top level collection per page', // @translate
                             ])
                             ->setValue($numericValue('collections-per-page', 3))
                     )
                     ->add(
                         (new Text('collection-manifests-per-page'))
                             ->setOptions([
-                                'label' => 'Manifests per collection',
-                                'info' => 'Amount of manifests to show per collection',
+                                'label' => 'Manifests per collection', // @translate
+                                'info' => 'Amount of manifests to show per collection', // @translate
                             ])
                             ->setValue($numericValue('collection-manifests-per-page', 5))
                     )
                     ->add(
                         (new Text('manifests-per-page'))
                             ->setOptions([
-                                'label' => 'Manifests per page',
-                                'info' => 'Amount of manifests to view on a collection per page',
+                                'label' => 'Manifests per page', // @translate
+                                'info' => 'Amount of manifests to view on a collection per page', // @translate
                             ])
                             ->setValue($numericValue('manifests-per-page', 24))
                     )
                     ->add(
                         (new Text('canvases-per-page'))
                             ->setOptions([
-                                'label' => 'Canvases per page',
-                                'info' => 'Amount of canvases to view on a manifest per page',
+                                'label' => 'Canvases per page', // @translate
+                                'info' => 'Amount of canvases to view on a manifest per page', // @translate
                             ])
                             ->setValue($numericValue('canvases-per-page', 12))
                     )
                     ->setOptions([
-                        'label' => 'IIIF Storage options',
+                        'label' => 'IIIF Storage options', // @translate
                     ])
             );
 
@@ -159,40 +159,40 @@ class Module extends AbstractModule implements ConfigProviderInterface
                     ->add(
                         (new Checkbox('cs-bookmarking'))
                             ->setOptions([
-                                'label' => 'Enable bookmarking',
-                                'info' => 'Allows logged in users to bookmark IIIF canvases'
+                                'label' => 'Enable bookmarking', // @translate
+                                'info' => 'Allows logged in users to bookmark IIIF canvases' // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('cs-bookmarking', true))
                     )
                     ->add(
                         (new Checkbox('cs-mark-as-complete'))
                             ->setOptions([
-                                'label' => 'Enable mark as complete',
-                                'info' => 'Allows users to mark a page as complete, allowing no further annotations'
+                                'label' => 'Enable mark as complete', // @translate
+                                'info' => 'Allows users to mark a page as complete, allowing no further annotations' // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('cs-mark-as-complete', true))
                     )
                     ->add(
                         (new Checkbox('cs-annotation-studio'))
                             ->setOptions([
-                                'label' => 'Enable user created annotations',
-                                'info' => 'Allows users to create annotations'
+                                'label' => 'Enable user created annotations', // @translate
+                                'info' => 'Allows users to create annotations' // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('cs-annotation-studio', true))
                     )
                     ->add(
                         (new Checkbox('cs-flagging'))
                             ->setOptions([
-                                'label' => 'Enable user flagging',
-                                'info' => 'Allows users to flag content (requires backend service)'
+                                'label' => 'Enable user flagging', // @translate
+                                'info' => 'Allows users to flag content (requires backend service)' // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('cs-flagging', true))
                     )
                     ->add(
                         (new Checkbox('cs-show-annotations'))
                             ->setOptions([
-                                'label' => 'Enable users to see annotations',
-                                'info' => 'Allows users to see created annotations'
+                                'label' => 'Enable users to see annotations', // @translate
+                                'info' => 'Allows users to see created annotations' // @translate
                             ])
                             ->setValue($form->getSiteSettings()->get('cs-show-annotations', true))
                     )
@@ -205,7 +205,7 @@ class Module extends AbstractModule implements ConfigProviderInterface
                             ->setValue($form->getSiteSettings()->get('cs-single-collection', true))
                     )
                     ->setOptions([
-                        'label' => 'Crowd sourcing',
+                        'label' => 'Crowd sourcing', // @translate
                     ])
             );
         });

--- a/repos/iiif-storage/asset/css/iiif-storage.css
+++ b/repos/iiif-storage/asset/css/iiif-storage.css
@@ -389,3 +389,18 @@
     background-color: transparent;
     color: #333;
 }
+
+.c-image {
+    position: relative;;
+}
+.c-image__status--started:after {
+    position: absolute;
+    bottom: -2px;
+    border: 2px solid #000;
+    right: -7px;
+    width: 14px;
+    height: 14px;
+    content: '';
+    background: dodgerblue;
+    border-radius: 50%;
+}

--- a/repos/iiif-storage/asset/css/iiif-storage.css
+++ b/repos/iiif-storage/asset/css/iiif-storage.css
@@ -377,6 +377,8 @@
 .c-button input[type="submit"],
 .c-button input[type="button"] {
     background: none;
+    color: #fff;
+    font-size: inherit;
     border: 0;
 }
 

--- a/repos/iiif-storage/asset/css/iiif-storage.css
+++ b/repos/iiif-storage/asset/css/iiif-storage.css
@@ -404,3 +404,10 @@
     background: dodgerblue;
     border-radius: 50%;
 }
+
+.info-panel {
+    background: palegoldenrod;
+    color: #333;
+    padding: 5px;
+    margin: 10px -5px;
+}

--- a/repos/iiif-storage/composer.json
+++ b/repos/iiif-storage/composer.json
@@ -2,7 +2,7 @@
   "name": "digirati/omeka-iiif-storage-module",
   "license": "MIT",
   "version": "1.0.0",
-  "description": "Omeka Sentry module",
+  "description": "Omeka IIIF Storage module",
   "type": "omeka-s-module",
   "require": {
     "digirati/omeka-shared": "~1.0.0",

--- a/repos/iiif-storage/config/service.config.php
+++ b/repos/iiif-storage/config/service.config.php
@@ -4,6 +4,7 @@ use Digirati\OmekaShared\Factory\EventDispatcherFactory;
 use Digirati\OmekaShared\Factory\LocaleFromRdfFactory;
 use Digirati\OmekaShared\Factory\LocaleHelperFactory;
 use Digirati\OmekaShared\Factory\ProxyClientFactory;
+use Digirati\OmekaShared\Factory\PropertyIdSaturatorFactory;
 use Digirati\OmekaShared\Factory\SettingsHelperFactory;
 use Digirati\OmekaShared\Factory\UrlHelperFactory;
 use Digirati\OmekaShared\Helper\LocaleHelper;
@@ -120,9 +121,7 @@ return [
                     ]
                 );
             },
-            PropertyIdSaturator::class => function (ContainerInterface $c) {
-                return new PropertyIdSaturator($c->get('Omeka\ApiManager'));
-            },
+            PropertyIdSaturator::class => PropertyIdSaturatorFactory::class,
             ScheduleEmbeddedCanvases::class => function (ContainerInterface $c) {
                 return new ScheduleEmbeddedCanvases(
                     $c->get(Dispatcher::class),

--- a/repos/iiif-storage/config/service.config.php
+++ b/repos/iiif-storage/config/service.config.php
@@ -46,7 +46,7 @@ use IIIFStorage\Media\ManifestSnippetIngester;
 use IIIFStorage\Media\ManifestSnippetRenderer;
 use IIIFStorage\Media\MetadataIngester;
 use IIIFStorage\Media\MetadataRenderer;
-use IIIFStorage\Media\PageBlockMediaAdapter;
+use Digirati\OmekaShared\Framework\PageBlockMediaAdapter;
 use IIIFStorage\Media\TopContributorsIngester;
 use IIIFStorage\Media\TopContributorsRenderer;
 use IIIFStorage\Repository\CanvasRepository;

--- a/repos/iiif-storage/src/Controller/CollectionController.php
+++ b/repos/iiif-storage/src/Controller/CollectionController.php
@@ -116,6 +116,12 @@ class CollectionController extends AbstractPsr7ActionController
             'router' => $this->router,
         ]);
 
+        $singleCollection = $this->siteSettings()->get('cs-single-collection', true);
+
+        if ($singleCollection && sizeof($omekaCollections) === 1) {
+            return $this->redirect()->toRoute('site/iiif-collection/view', ['collection' => $omekaCollections[0]->id()], [], true);
+        }
+
         $this->paginate($viewModel, 'itemSets', $omekaCollections, $this->getCollectionsPerPage());
 
         $collections = array_map(

--- a/repos/iiif-storage/src/Controller/ManifestController.php
+++ b/repos/iiif-storage/src/Controller/ManifestController.php
@@ -186,7 +186,7 @@ class ManifestController extends AbstractPsr7ActionController
         if ($manifestId) {
             $manifest = $this->repo->getById($manifestId);
 
-            if (!$this->repo->containsCanvas($manifest->id(), $canvas->getId())) {
+            if (!$this->repo->containsCanvas($manifest->id(), $canvas->getOmekaId(), $canvas->getId())) {
                 throw new NotFoundException();
             }
 

--- a/repos/iiif-storage/src/Controller/ManifestController.php
+++ b/repos/iiif-storage/src/Controller/ManifestController.php
@@ -185,9 +185,14 @@ class ManifestController extends AbstractPsr7ActionController
 
         if ($manifestId) {
             $manifest = $this->repo->getById($manifestId);
-            if (!$this->repo->containsCanvas($manifest->id(), $canvasId)) {
+
+            if (!$this->repo->containsCanvas($manifest->id(), $canvas->getId())) {
                 throw new NotFoundException();
             }
+
+            // Temporary fix.
+            $vm['isClone'] = !$this->repo->containsCanvas($manifest->id(), $canvasId);
+
             $canvasPage = 1;
             $canvasesToLoad = 1;
             $manifestRepresentation = $this->builder->buildResource(

--- a/repos/iiif-storage/src/Job/ImportCanvases.php
+++ b/repos/iiif-storage/src/Job/ImportCanvases.php
@@ -140,6 +140,7 @@ class ImportCanvases extends AbstractJob implements JobInterface
         try {
             return $api->create('items', $item->export())->getContent();
         } catch (Throwable $e) {
+            $logger->warn((string) $e);
             $logger->warn('Failed to import canvas, trying without media');
             try {
                 $export = $item->export();

--- a/repos/iiif-storage/src/Media/BannerImageIngester.php
+++ b/repos/iiif-storage/src/Media/BannerImageIngester.php
@@ -3,9 +3,9 @@
 
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\MutableIngesterInterface;
 use Omeka\Form\Element;
-use Zend\View\Renderer\PhpRenderer;
 
 class BannerImageIngester extends AbstractIngester implements MutableIngesterInterface
 {

--- a/repos/iiif-storage/src/Media/BannerImageRenderer.php
+++ b/repos/iiif-storage/src/Media/BannerImageRenderer.php
@@ -2,14 +2,14 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\RenderMedia;
 use Omeka\Api\Exception\NotFoundException;
-use Omeka\Api\Representation\MediaRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Media\Renderer\RendererInterface;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;
 use ZfcTwig\View\TwigRenderer;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
 
 class BannerImageRenderer implements RendererInterface, MediaPageBlockDualRender
 {

--- a/repos/iiif-storage/src/Media/CanvasListIngester.php
+++ b/repos/iiif-storage/src/Media/CanvasListIngester.php
@@ -3,13 +3,9 @@
 
 namespace IIIFStorage\Media;
 
-
-use Omeka\Api\Request;
-use Omeka\Entity\Media;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\IngesterInterface;
-use Omeka\Stdlib\ErrorStore;
 use Zend\Form\Element;
-use Zend\View\Renderer\PhpRenderer;
 
 class CanvasListIngester extends AbstractIngester implements IngesterInterface
 {

--- a/repos/iiif-storage/src/Media/CanvasListRenderer.php
+++ b/repos/iiif-storage/src/Media/CanvasListRenderer.php
@@ -2,7 +2,7 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\RenderMedia;
 use IIIFStorage\JsonBuilder\CanvasBuilder;
 use IIIFStorage\Repository\CanvasRepository;
 use IIIFStorage\Repository\ManifestRepository;
@@ -12,6 +12,7 @@ use Omeka\Media\Renderer\RendererInterface;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;
 use ZfcTwig\View\TwigRenderer;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
 
 class CanvasListRenderer implements RendererInterface, MediaPageBlockDualRender
 {

--- a/repos/iiif-storage/src/Media/CanvasSnippetIngester.php
+++ b/repos/iiif-storage/src/Media/CanvasSnippetIngester.php
@@ -2,15 +2,12 @@
 
 namespace IIIFStorage\Media;
 
-use IIIFStorage\Repository\ManifestRepository;
 use Digirati\OmekaShared\Utility\PropertyIdSaturator;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use IIIFStorage\Utility\CheapOmekaRelationshipRequest;
 use Omeka\Api\Manager;
 use Omeka\Api\Representation\ItemRepresentation;
-use Omeka\Api\Representation\ValueRepresentation;
-use Omeka\Form\Element\ResourceSelect;
 use Omeka\Media\Ingester\IngesterInterface;
-use Throwable;
 use Zend\Form\Element;
 use Zend\View\Renderer\PhpRenderer;
 

--- a/repos/iiif-storage/src/Media/CanvasSnippetRenderer.php
+++ b/repos/iiif-storage/src/Media/CanvasSnippetRenderer.php
@@ -2,15 +2,15 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\RenderMedia;
+use Digirati\OmekaShared\Framework\TranslatableRenderer;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
 use IIIFStorage\JsonBuilder\CanvasBuilder;
 use IIIFStorage\Repository\CanvasRepository;
 use IIIFStorage\Utility\Router;
 use Omeka\Api\Manager;
 use Omeka\Api\Representation\ItemRepresentation;
-use Omeka\Api\Representation\MediaRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
-use Omeka\Api\Representation\ValueRepresentation;
 use Omeka\Media\Renderer\RendererInterface;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;

--- a/repos/iiif-storage/src/Media/CollectionListIngester.php
+++ b/repos/iiif-storage/src/Media/CollectionListIngester.php
@@ -3,13 +3,9 @@
 
 namespace IIIFStorage\Media;
 
-
-use Omeka\Api\Request;
-use Omeka\Entity\Media;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\IngesterInterface;
-use Omeka\Stdlib\ErrorStore;
 use Zend\Form\Element;
-use Zend\View\Renderer\PhpRenderer;
 
 class CollectionListIngester extends AbstractIngester implements IngesterInterface
 {

--- a/repos/iiif-storage/src/Media/CollectionListRenderer.php
+++ b/repos/iiif-storage/src/Media/CollectionListRenderer.php
@@ -2,11 +2,11 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
+use Digirati\OmekaShared\Framework\RenderMedia;
 use IIIFStorage\JsonBuilder\CollectionBuilder;
 use IIIFStorage\Repository\CollectionRepository;
 use IIIFStorage\Utility\Router;
-use Omeka\Api\Representation\MediaRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Media\Renderer\RendererInterface;
 use Zend\View\Model\ViewModel;

--- a/repos/iiif-storage/src/Media/CollectionSnippetIngester.php
+++ b/repos/iiif-storage/src/Media/CollectionSnippetIngester.php
@@ -3,6 +3,7 @@
 namespace IIIFStorage\Media;
 
 use Digirati\OmekaShared\Utility\PropertyIdSaturator;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Api\Manager;
 use Omeka\Api\Representation\ItemRepresentation;
 use Omeka\Form\Element\ResourceSelect;

--- a/repos/iiif-storage/src/Media/CollectionSnippetRenderer.php
+++ b/repos/iiif-storage/src/Media/CollectionSnippetRenderer.php
@@ -2,7 +2,8 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
+use Digirati\OmekaShared\Framework\RenderMedia;
 use IIIFStorage\JsonBuilder\CollectionBuilder;
 use IIIFStorage\Utility\Router;
 use Omeka\Api\Manager;

--- a/repos/iiif-storage/src/Media/CrowdSourcingBannerIngester.php
+++ b/repos/iiif-storage/src/Media/CrowdSourcingBannerIngester.php
@@ -2,13 +2,13 @@
 
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Api\Manager;
 use Omeka\Form\Element\Asset;
 use Omeka\Form\Element\HtmlTextarea;
 use Omeka\Form\Element\ItemSetSelect;
 use Omeka\Media\Ingester\IngesterInterface;
 use Zend\Form\Element;
-use Zend\View\Renderer\PhpRenderer;
 
 class CrowdSourcingBannerIngester extends AbstractIngester implements IngesterInterface
 {

--- a/repos/iiif-storage/src/Media/CrowdSourcingBannerRenderer.php
+++ b/repos/iiif-storage/src/Media/CrowdSourcingBannerRenderer.php
@@ -2,6 +2,10 @@
 
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\RenderMedia;
+use Digirati\OmekaShared\Framework\LocalisedMedia;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
+use Digirati\OmekaShared\Framework\TranslatableRenderer;
 use Digirati\OmekaShared\Helper\LocaleHelper;
 use IIIFStorage\Utility\Router;
 use Omeka\Api\Exception\NotFoundException;

--- a/repos/iiif-storage/src/Media/HtmlIngester.php
+++ b/repos/iiif-storage/src/Media/HtmlIngester.php
@@ -2,6 +2,7 @@
 
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Form\Element\Ckeditor;
 use Omeka\Media\Ingester\IngesterInterface;
 use Omeka\Stdlib\ErrorStore;

--- a/repos/iiif-storage/src/Media/HtmlRenderer.php
+++ b/repos/iiif-storage/src/Media/HtmlRenderer.php
@@ -2,6 +2,10 @@
 
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\RenderMedia;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
+use Digirati\OmekaShared\Framework\TranslatableRenderer;
+use Digirati\OmekaShared\Framework\LocalisedMedia;
 use Digirati\OmekaShared\Helper\LocaleHelper;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Media\Renderer\RendererInterface;

--- a/repos/iiif-storage/src/Media/IIIFImageIngester.php
+++ b/repos/iiif-storage/src/Media/IIIFImageIngester.php
@@ -1,6 +1,7 @@
 <?php
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Entity\Media;
 use Omeka\File\Downloader;
 use Omeka\Media\Ingester\IngesterInterface;
@@ -135,6 +136,8 @@ class IIIFImageIngester extends AbstractIngester implements IngesterInterface
             }
             $tempFile->delete();
         }
+
+        return true;
     }
 
     //This check comes from Open Seadragon's own validation check
@@ -221,6 +224,7 @@ class IIIFImageIngester extends AbstractIngester implements IngesterInterface
 
     private function getThumbnailService($thumbnailService, $fallback, $errorStore)
     {
+        /** @var ErrorStore $errorStore */
         try {
             $uri = new HttpUri($thumbnailService);
             if (!($uri->isValid() && $uri->isAbsolute())) {

--- a/repos/iiif-storage/src/Media/IIIFImageIngester.php
+++ b/repos/iiif-storage/src/Media/IIIFImageIngester.php
@@ -118,14 +118,6 @@ class IIIFImageIngester extends AbstractIngester implements IngesterInterface
                 return false;
             }
 
-            //Check if valid IIIF data
-            if ($this->validate($IIIFData)) {
-                $media->setData($IIIFData);
-            } else {
-                $errorStore->addError('o:source', 'URL does not link to IIIF JSON');
-                return false;
-            }
-
             $thumbnailUrl = implode('/', [
                 $id,
                 'full',
@@ -135,6 +127,13 @@ class IIIFImageIngester extends AbstractIngester implements IngesterInterface
             ]);
         }
 
+        //Check if valid IIIF data
+        if ($this->validate($IIIFData)) {
+            $media->setData($IIIFData);
+        } else {
+            $errorStore->addError('o:source', 'URL does not link to IIIF JSON');
+            return false;
+        }
 
         $tempFile = $this->downloader->download($thumbnailUrl);
         if ($tempFile) {

--- a/repos/iiif-storage/src/Media/IIIFImageIngester.php
+++ b/repos/iiif-storage/src/Media/IIIFImageIngester.php
@@ -103,6 +103,9 @@ class IIIFImageIngester extends AbstractIngester implements IngesterInterface
 
         $thumbnailSize = $data['thumbnail-size'] ?? $this->defaultThumbnailSize;
         $thumbnailSize = $thumbnailSize ? $thumbnailSize : 256;
+        if (is_array($thumbnailSize)) {
+            $thumbnailSize = $thumbnailSize['@value'] ?? 256;
+        }
         $getImageApiVersion = $this->getImageApiVersion($thumbnailIIIData['@context']);
         $fileName = $getImageApiVersion == 2 ? 'default' : 'native';
         $format = 'jpg'; // @todo customise - this is required for level0 support.
@@ -255,7 +258,7 @@ class IIIFImageIngester extends AbstractIngester implements IngesterInterface
         }
     }
 
-    private function getSizesFromService(array $thumbnailIIIData, int $thumbnailSize): string
+    private function getSizesFromService(array $thumbnailIIIData, $thumbnailSize): string
     {
         $sizes = $thumbnailIIIData['sizes'] ?? null;
         $fallback = "$thumbnailSize,";

--- a/repos/iiif-storage/src/Media/LatestAnnotatedImagesIngester.php
+++ b/repos/iiif-storage/src/Media/LatestAnnotatedImagesIngester.php
@@ -2,7 +2,7 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\IngesterInterface;
 use Zend\Form\Element;
 

--- a/repos/iiif-storage/src/Media/LatestAnnotatedImagesRenderer.php
+++ b/repos/iiif-storage/src/Media/LatestAnnotatedImagesRenderer.php
@@ -2,6 +2,10 @@
 
 namespace IIIFStorage\Media;
 
+use Digirati\OmekaShared\Framework\RenderMedia;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
+use Digirati\OmekaShared\Framework\TranslatableRenderer;
+use Digirati\OmekaShared\Framework\LocalisedMedia;
 use Digirati\OmekaShared\Helper\LocaleHelper;
 use Doctrine\DBAL\Connection;
 use IIIFStorage\JsonBuilder\CanvasBuilder;

--- a/repos/iiif-storage/src/Media/ManifestListIngester.php
+++ b/repos/iiif-storage/src/Media/ManifestListIngester.php
@@ -1,15 +1,10 @@
 <?php
 
-
 namespace IIIFStorage\Media;
 
-
-use Omeka\Api\Request;
-use Omeka\Entity\Media;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\IngesterInterface;
-use Omeka\Stdlib\ErrorStore;
 use Zend\Form\Element;
-use Zend\View\Renderer\PhpRenderer;
 
 class ManifestListIngester extends AbstractIngester implements IngesterInterface
 {

--- a/repos/iiif-storage/src/Media/ManifestListRenderer.php
+++ b/repos/iiif-storage/src/Media/ManifestListRenderer.php
@@ -2,11 +2,11 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\RenderMedia;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
 use IIIFStorage\JsonBuilder\ManifestBuilder;
 use IIIFStorage\Repository\ManifestRepository;
 use IIIFStorage\Utility\Router;
-use Omeka\Api\Representation\MediaRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Media\Renderer\RendererInterface;
 use Zend\View\Model\ViewModel;

--- a/repos/iiif-storage/src/Media/ManifestSnippetIngester.php
+++ b/repos/iiif-storage/src/Media/ManifestSnippetIngester.php
@@ -3,9 +3,8 @@
 namespace IIIFStorage\Media;
 
 use Digirati\OmekaShared\Utility\PropertyIdSaturator;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Api\Manager;
-use Omeka\Api\Representation\ItemRepresentation;
-use Omeka\Form\Element\ResourceSelect;
 use Omeka\Media\Ingester\IngesterInterface;
 use Zend\Form\Element;
 use Zend\View\Renderer\PhpRenderer;

--- a/repos/iiif-storage/src/Media/ManifestSnippetRenderer.php
+++ b/repos/iiif-storage/src/Media/ManifestSnippetRenderer.php
@@ -3,6 +3,8 @@
 namespace IIIFStorage\Media;
 
 
+use Digirati\OmekaShared\Framework\RenderMedia;
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
 use IIIFStorage\JsonBuilder\ManifestBuilder;
 use IIIFStorage\Repository\ManifestRepository;
 use IIIFStorage\Utility\Router;

--- a/repos/iiif-storage/src/Media/MetadataIngester.php
+++ b/repos/iiif-storage/src/Media/MetadataIngester.php
@@ -1,16 +1,11 @@
 <?php
 
-
 namespace IIIFStorage\Media;
 
-
-use Omeka\Api\Request;
-use Omeka\Entity\Media;
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\IngesterInterface;
-use Omeka\Stdlib\ErrorStore;
 use Zend\Form\Element;
 use Zend\Form\Element\Checkbox;
-use Zend\View\Renderer\PhpRenderer;
 
 class MetadataIngester extends AbstractIngester implements IngesterInterface
 {

--- a/repos/iiif-storage/src/Media/MetadataRenderer.php
+++ b/repos/iiif-storage/src/Media/MetadataRenderer.php
@@ -2,7 +2,6 @@
 
 namespace IIIFStorage\Media;
 
-
 use IIIFStorage\JsonBuilder\CanvasBuilder;
 use IIIFStorage\JsonBuilder\CollectionBuilder;
 use IIIFStorage\JsonBuilder\ManifestBuilder;

--- a/repos/iiif-storage/src/Media/TopContributorsIngester.php
+++ b/repos/iiif-storage/src/Media/TopContributorsIngester.php
@@ -2,7 +2,7 @@
 
 namespace IIIFStorage\Media;
 
-
+use Digirati\OmekaShared\Framework\AbstractIngester;
 use Omeka\Media\Ingester\IngesterInterface;
 use Zend\Form\Element;
 

--- a/repos/iiif-storage/src/Repository/ManifestRepository.php
+++ b/repos/iiif-storage/src/Repository/ManifestRepository.php
@@ -219,8 +219,8 @@ class ManifestRepository
                 $nextLength = $number;
 
                 return [
-                  'previous' => $hasPrevious ? array_slice($canvases, $previousStart, $previousLength) : [],
-                  'next' => $hasNext ? array_slice($canvases, $nextStart, $nextLength) : [],
+                    'previous' => $hasPrevious ? array_slice($canvases, $previousStart, $previousLength) : [],
+                    'next' => $hasNext ? array_slice($canvases, $nextStart, $nextLength) : [],
                 ];
             }
         }
@@ -247,7 +247,7 @@ class ManifestRepository
         return $this->relationshipRequest->getEtag($resourceId);
     }
 
-    public function containsCanvas(int $manifest, string $canvasId): bool
+    public function containsCanvas(int $manifest, string $canvasId, string $alt = null): bool
     {
         try {
             $canvasMapping = $this->relationshipRequest->getUriMapping(
@@ -261,8 +261,10 @@ class ManifestRepository
 
         foreach ($canvasMapping->getList() as $omekaId => $urlId) {
             if (
-                (string)$omekaId === (string)$canvasId ||
-                (string)$urlId === (string)$canvasId
+            (string)$omekaId === (string)$canvasId ||
+            (string)$urlId === (string)$canvasId ||
+            (string)$omekaId === (string)$alt ||
+            (string)$urlId === (string)$alt
             ) {
                 return true;
             }
@@ -270,7 +272,8 @@ class ManifestRepository
         return false;
     }
 
-    public function getTotalCanvases(int $manifestId) {
+    public function getTotalCanvases(int $manifestId)
+    {
         $canvases = $this->getCanvasMapFromManifest($manifestId);
 
         return $canvases->getTotalResults();

--- a/repos/iiif-storage/src/Utility/CheapOmekaRelationshipRequest.php
+++ b/repos/iiif-storage/src/Utility/CheapOmekaRelationshipRequest.php
@@ -125,6 +125,10 @@ SQL;
         $indexMap = [];
         foreach ($statement->fetchAll() as $canvas) {
             if ($canvas['uri']) {
+                if (isset($indexMap[$canvas['uri']])) {
+                    error_log('Found duplicate Omeka ID: "' . $canvas['omeka_id'] . '" which is ignored');
+                    continue;
+                }
                 $indexMap[$canvas['uri']] = $canvas['omeka_id'];
             }
         }

--- a/repos/iiif-storage/src/Utility/Router.php
+++ b/repos/iiif-storage/src/Utility/Router.php
@@ -230,7 +230,7 @@ class Router
         // NOTE: This is last resort to show something to user.
         $id = is_string($entityOrId) ? $entityOrId : $entityOrId->getId();
 
-        // A better default path, where an ID was already passed in.
+        // A better default path, where an ID was already passed in
         if (is_numeric($id)) {
             return $id;
         }

--- a/repos/iiif-storage/src/Utility/Router.php
+++ b/repos/iiif-storage/src/Utility/Router.php
@@ -229,6 +229,12 @@ class Router
         // It might be possible to extract ID.
         // NOTE: This is last resort to show something to user.
         $id = is_string($entityOrId) ? $entityOrId : $entityOrId->getId();
+
+        // A better default path, where an ID was already passed in.
+        if (is_numeric($id)) {
+            return $id;
+        }
+
         if (strpos($id, 'iiif/api') !== false) {
             $id = array_pop(explode('/', array_shift(explode('?', $id))));
             if ($id) {
@@ -236,9 +242,10 @@ class Router
             }
         }
 
-        // A better default path, where an ID was already passed in.
-        if (is_numeric($id)) {
-            return $id;
+        // One more case, we might have a string that is the full URL of the manifest.
+        $resource = $this->canvas->getByResource($id);
+        if ($resource) {
+            return $resource;
         }
 
         throw new \LogicException('Entity ID not found');

--- a/repos/iiif-storage/view/iiif-storage/canvas/view-image.twig
+++ b/repos/iiif-storage/view/iiif-storage/canvas/view-image.twig
@@ -6,7 +6,7 @@
     siteSetting('cs-annotation-studio', true) or
     siteSetting('cs-flagging', true) or
     siteSetting('cs-show-annotations', true) or
-    siteSetting('cs-annotation-studio', true) ? pageMarkedAsComplete != 1 and currentUser : false
+    (siteSetting('cs-annotation-studio', true) ? pageMarkedAsComplete != 1 and currentUser : false)
 )) %}
     <div class="iiif-view-annotation-studio" id="annotation-studio">
         <div class="iiif-view-annotation-studio__viewer">

--- a/repos/iiif-storage/view/iiif-storage/manifest/view-canvas.twig
+++ b/repos/iiif-storage/view/iiif-storage/manifest/view-canvas.twig
@@ -2,6 +2,12 @@
 
 {% include 'iiif-storage/partials/breadcrumbs' %}
 
+{% if currentUser and currentUser.role == 'global_admin' and isClone %}
+    <div class="info-panel">
+        <strong>Warning</strong>: This resource may be duplicated in this manifest
+    </div>
+{% endif %}
+
 {% if renderMetadata %}
     {% set title = canvas.getLabel() | default(manifest.getLabel()) %}
     {% include 'iiif-storage/partials/title.twig' %}
@@ -12,7 +18,6 @@
 {% include 'iiif-storage/partials/canvas-navigation.twig' %}
 
 {% include 'iiif-storage/partials/canvas-status.twig' %}
-
 {% for mediaItem in media %}
     {{ mediaItem.render({ context: _context }) | raw }}
 {% endfor %}

--- a/repos/iiif-storage/view/iiif-storage/partials/canvas-mark-as-complete.twig
+++ b/repos/iiif-storage/view/iiif-storage/partials/canvas-mark-as-complete.twig
@@ -1,35 +1,35 @@
 {% if (isLoggedIn and siteSetting('cs-mark-as-complete', true)) %}
     <li>
-        {% if (pageMarkedAsComplete == false) %}
-            {% do headScript().prependFile(assetUrl('js/mark-as-complete.js', 'IIIFStorage')) %}
-            {% do headLink().prependStylesheet(assetUrl('css/modal.css', 'IIIFStorage')) %}
+        {% do headScript().prependFile(assetUrl('js/mark-as-complete.js', 'IIIFStorage')) %}
+        {% do headLink().prependStylesheet(assetUrl('css/modal.css', 'IIIFStorage')) %}
 
-            <a data-mark-as-complete="mark-as-complete" href="#mark-as-complete" class="c-action"
-               aria-label="{{ translate('Mark as complete') }}">
+        <a data-mark-as-complete="mark-as-complete" href="#mark-as-complete" class="c-action"
+           aria-label="{{ translate('Mark as complete') }}">
+            {% if (pageMarkedAsComplete == false) %}
                 <span class="fa fa-check" aria-hidden="true"></span>{{ translate('Mark as complete') }}
-            </a>
+            {% else %}
+                <span class="fa fa-plus" aria-hidden="true"></span>{{ translate('This page needs more work') }}
+            {% endif %}
+        </a>
 
-            <div id="mark-as-complete">
-                {% if (pageMarkedAsComplete) %}
-                    <h2 class="h3">{{ translate('Is this page complete?') }}</h2>
-                    <p>
-                        {{ translate('This page has been marked as completed.<br/>
+        <div id="mark-as-complete">
+            {% if (pageMarkedAsComplete) %}
+                <h2 class="h3">{{ translate('Is this page complete?') }}</h2>
+                <p>
+                    {{ translate('This page has been marked as completed.<br/>
                         You can mark as incomplete if it needs more work.') }}
-                    </p>
-                {% else %}
-                    <h2 class="h3">{{ translate('Is this page complete?') }}</h2>
-                    <p>
-                        {{ translate('Marking this page as complete helps us to understand the progress of annotations.') }}
-                    </p>
-                {% endif %}
-                {% if (completionForm) %}
-                    <div class="c-button c-button--primary">
-                        {% include 'elucidate/completion/form' with { form: completionForm.withRedirect(router.canvas(canvas, manifest, collection)) } %}
-                    </div>
-                {% endif %}
-            </div>
-        {% else %}
-            {{ translate('Page marked as complete') }}
-        {% endif %}
+                </p>
+            {% else %}
+                <h2 class="h3">{{ translate('Is this page complete?') }}</h2>
+                <p>
+                    {{ translate('Marking this page as complete helps us to understand the progress of annotations.') }}
+                </p>
+            {% endif %}
+            {% if (completionForm) %}
+                <div class="c-button c-button--primary">
+                    {% include 'elucidate/completion/form' with { form: completionForm.withRedirect(router.canvas(canvas, manifest, collection)) } %}
+                </div>
+            {% endif %}
+        </div>
     </li>
 {% endif %}

--- a/repos/iiif-storage/view/iiif-storage/partials/canvas-thumbnail.twig
+++ b/repos/iiif-storage/view/iiif-storage/partials/canvas-thumbnail.twig
@@ -15,7 +15,7 @@
                     {% set statusClass = 'not-started' %}
                     {% set statusTitle = translate('Editing not started') %}
                 {% endif %}
-                <div class="c-image__status c-image__status--{{ statusClass }}" title="{{ statusTitle }}"></div>
+                <div class="c-image__status c-image__status--{{ statusClass }}" title="{{ statusTitle }} ({{ image.edited ? image.edited : '0' }} edited, {{ image.completed ? image.completed : '0' }} completed)"></div>
             {% endif %}
         </div>
     </a>

--- a/repos/public-user/Module.php
+++ b/repos/public-user/Module.php
@@ -29,6 +29,7 @@ use PublicUser\Settings\PublicUserSettings;
 use PublicUser\Site\SiteProvider;
 use PublicUser\Subscriber\AnnotationCreatorElucidateSubscriber;
 use PublicUser\Subscriber\AnnotationStatsSubscriber;
+use PublicUser\Subscriber\PreDeleteCanvasSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Throwable;
 use Zend\Authentication\AuthenticationService;
@@ -383,6 +384,10 @@ class Module extends AbstractModule
             $layoutViewModel->setVariable('isLoggedIn', !!$user);
             $layoutViewModel->setVariable('currentUser', $user);
         });
+
+        // Pre-delete
+        $preDelete = $serviceContainer->get(PreDeleteCanvasSubscriber::class);
+        $preDelete->attach($sharedEventManager);
 
         $acl = $serviceContainer->get('Omeka\Acl');
         $roles = $acl->getRoleLabels();

--- a/repos/public-user/Module.php
+++ b/repos/public-user/Module.php
@@ -29,6 +29,7 @@ use PublicUser\Settings\PublicUserSettings;
 use PublicUser\Site\SiteProvider;
 use PublicUser\Subscriber\AnnotationCreatorElucidateSubscriber;
 use PublicUser\Subscriber\AnnotationStatsSubscriber;
+use PublicUser\Subscriber\ManifestStatsSubscriber;
 use PublicUser\Subscriber\PreDeleteCanvasSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Throwable;
@@ -388,6 +389,10 @@ class Module extends AbstractModule
         // Pre-delete
         $preDelete = $serviceContainer->get(PreDeleteCanvasSubscriber::class);
         $preDelete->attach($sharedEventManager);
+
+        // Manifest stats
+        $manifestStats = $serviceContainer->get(ManifestStatsSubscriber::class);
+        $manifestStats->attach($sharedEventManager);
 
         $acl = $serviceContainer->get('Omeka\Acl');
         $roles = $acl->getRoleLabels();

--- a/repos/public-user/asset/css/statistics.css
+++ b/repos/public-user/asset/css/statistics.css
@@ -1,0 +1,110 @@
+.c-statistics {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: row;
+    flex-direction: row;
+}
+
+.c-statistics--center {
+    -ms-flex-pack: center;
+    justify-content: center;
+}
+
+.c-statistic {
+    font-size: 14px;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -ms-flex-pack: top;
+    justify-content: top;
+    -ms-flex-align: center;
+    align-items: center;
+    margin: 0;
+    text-align: center;
+    padding: 15px 20px;
+    min-width: 0;
+}
+
+.c-statistic:after {
+    clear: both;
+    content: "";
+    display: table;
+}
+
+.c-statistic:hover {
+    background-color: #f2f3f4;
+}
+
+.c-statistic dd {
+    color: inherit;
+    font-family: "Lato", Arial, "Helvetica Neue", Helvetica, sans-serif;
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 0.6em 0;
+    padding: 0;
+    margin: 0;
+    font-size: 1.2em;
+    -ms-flex-order: 0;
+    order: 0;
+    margin: 0;
+}
+
+.c-statistic dt {
+    -ms-flex-order: 1;
+    order: 1;
+}
+
+.c-statistic--inline {
+    -ms-flex-direction: row;
+    flex-direction: row;
+    padding: 0 15px;
+}
+
+.c-statistic--inline dd {
+    padding-right: 7px;
+}
+
+.c-statistic--sm dd {
+    font-size: 2em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--sm dd {
+        font-size: 1.4em;
+    }
+}
+
+.c-statistic--md dd {
+    font-size: 3em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--md dd {
+        font-size: 2em;
+    }
+}
+
+.c-statistic--lg dd {
+    font-size: 4em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--lg dd {
+        font-size: 3em;
+    }
+}
+
+.c-statistic--xl {
+    padding: 15px 40px;
+}
+
+.c-statistic--xl dd {
+    font-size: 6em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--xl dd {
+        font-size: 4em;
+    }
+}

--- a/repos/public-user/config/services.config.php
+++ b/repos/public-user/config/services.config.php
@@ -17,6 +17,7 @@ use PublicUser\Stats\ContributorsService;
 use PublicUser\Subscriber\AnnotationCreatorElucidateSubscriber;
 use PublicUser\Subscriber\AnnotationStatsSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use PublicUser\Subscriber\PreDeleteCanvasSubscriber;
 
 return [
     'service_manager' => [
@@ -48,32 +49,32 @@ return [
                 );
             },
 
-            TokenStorage::class => function ($container) {
+            TokenStorage::class => function (ContainerInterface $container) {
                 return new TokenStorage(
                     $container->get('Omeka\Connection')
                 );
             },
 
-            ContributorsService::class => function ($container) {
+            ContributorsService::class => function (ContainerInterface $container) {
                 return new ContributorsService(
                     $container->get('Omeka\Connection')
                 );
             },
 
-            BookmarksService::class => function ($container) {
+            BookmarksService::class => function (ContainerInterface $container) {
                 return new BookmarksService(
                     $container->get(GuzzleHttp\Client::class),
                     $container->get('Omeka\Connection')
                 );
             },
 
-            AnnotationStatisticsService::class => function ($container) {
+            AnnotationStatisticsService::class => function (ContainerInterface $container) {
                 return new AnnotationStatisticsService(
                     $container->get('Omeka\Connection')
                 );
             },
 
-            AnnotationStatsSubscriber::class => function ($container) {
+            AnnotationStatsSubscriber::class => function (ContainerInterface $container) {
                 return new AnnotationStatsSubscriber(
                     $container->get('Omeka\ApiManager'),
                     $container->get('Omeka\Connection'),
@@ -94,6 +95,13 @@ return [
 
             AnnotationCreatorElucidateSubscriber::class => function () {
                 return new AnnotationCreatorElucidateSubscriber();
+            },
+
+            PreDeleteCanvasSubscriber::class => function (ContainerInterface $container) {
+                return new PreDeleteCanvasSubscriber(
+                    $container->get('Omeka\Logger'),
+                    $container->get('Omeka\Connection')
+                );
             },
         ],
     ],

--- a/repos/public-user/config/services.config.php
+++ b/repos/public-user/config/services.config.php
@@ -1,7 +1,9 @@
 <?php
 
+use Digirati\OmekaShared\Factory\PropertyIdSaturatorFactory;
 use Digirati\OmekaShared\Factory\SettingsHelperFactory;
 use Digirati\OmekaShared\Helper\SettingsHelper;
+use Digirati\OmekaShared\Utility\PropertyIdSaturator;
 use PublicUser\Auth\TokenService;
 use PublicUser\Auth\TokenStorage;
 use PublicUser\Extension\ConfigurableMailer;
@@ -17,6 +19,7 @@ use PublicUser\Stats\ContributorsService;
 use PublicUser\Subscriber\AnnotationCreatorElucidateSubscriber;
 use PublicUser\Subscriber\AnnotationStatsSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use PublicUser\Subscriber\ManifestStatsSubscriber;
 use PublicUser\Subscriber\PreDeleteCanvasSubscriber;
 
 return [
@@ -27,6 +30,7 @@ return [
             },
             SettingsHelper::class => SettingsHelperFactory::class,
             ConfigurableMailer::class => ConfigurableMailerFactory::class,
+            PropertyIdSaturator::class => PropertyIdSaturatorFactory::class,
             PublicUserSettings::class => function (ContainerInterface $container) {
                 return new PublicUserSettings(
                     $container->get('Omeka\Settings'),
@@ -103,6 +107,13 @@ return [
                     $container->get('Omeka\Connection')
                 );
             },
+
+            ManifestStatsSubscriber::class => function (ContainerInterface $c) {
+                return new ManifestStatsSubscriber(
+                    $c->get('Omeka\Connection'),
+                    $c->get(PropertyIdSaturator::class)
+                );
+            }
         ],
     ],
 ];

--- a/repos/public-user/src/Controller/AccountController.php
+++ b/repos/public-user/src/Controller/AccountController.php
@@ -65,20 +65,18 @@ class AccountController extends AbstractActionController
                 'include_key' => false,
             ];
 
-        $manifest = [
-            'statistics' => [
-                [
-                    'label' => 'Bookmarked images', // @translate
-                    'value' => $stats->getBookmarks(),
-                ],
-                [
-                    'label' => 'Images annotated', // @translate
-                    'value' => $stats->getIncompleteImages(),
-                ],
-                [
-                    'label' => 'Total annotations', // @translate
-                    'value' => $stats->getIncompleteAnnotations() + $stats->getCompleteAnnotations(),
-                ],
+        $statistics = [
+            [
+                'label' => 'Bookmarked images', // @translate
+                'value' => $stats->getBookmarks(),
+            ],
+            [
+                'label' => 'Images annotated', // @translate
+                'value' => $stats->getIncompleteImages(),
+            ],
+            [
+                'label' => 'Total annotations', // @translate
+                'value' => $stats->getIncompleteAnnotations() + $stats->getCompleteAnnotations(),
             ],
         ];
 
@@ -96,14 +94,14 @@ class AccountController extends AbstractActionController
 
         $form->setData($formData);
 
-        $returnError = function() use ($view, $form, $manifest, $user) {
+        $returnError = function () use ($view, $form, $statistics, $user) {
             $view->setVariable('form', $form);
 
             $this->messenger()->addFormErrors($form);
 
             $view->setVariable('form', $form);
             $view->setVariable('user', $user);
-            $view->setVariable('manifest', $manifest);
+            $view->setVariable('statistics', $statistics);
 
             return $view;
         };
@@ -152,7 +150,7 @@ class AccountController extends AbstractActionController
 
         $view->setVariable('form', $form);
         $view->setVariable('user', $user);
-        $view->setVariable('manifest', $manifest);
+        $view->setVariable('statistics', $statistics);
 
         return $view;
     }

--- a/repos/public-user/src/Subscriber/ManifestStatsSubscriber.php
+++ b/repos/public-user/src/Subscriber/ManifestStatsSubscriber.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace PublicUser\Subscriber;
+
+use Digirati\OmekaShared\Utility\PropertyIdSaturator;
+use Doctrine\DBAL\Connection;
+use IIIFStorage\Model\ManifestRepresentation;
+use Throwable;
+use Zend\EventManager\Event;
+use Zend\EventManager\SharedEventManagerInterface;
+use Zend\View\Model\ViewModel;
+
+class ManifestStatsSubscriber
+{
+    /**
+     * @var Connection
+     */
+    private $db;
+
+    private static $GET_STATS = <<<SQL
+SELECT
+  V2.value_resource_id as canvas_id,
+  UC.bookmarked as bookmarks,
+  UC.incomplete_count as incomplete_count,
+  UC.complete_count as complete_count
+FROM value V2
+  LEFT JOIN value V1 on V1.resource_id = V2.value_resource_id
+  LEFT JOIN user_canvas_mapping UC on UC.canvas_mapping_id = V2.value_resource_id
+WHERE V2.property_id = :hasCanvases
+  AND V1.property_id = 10
+  AND V2.resource_id = :manifestId;
+SQL;
+    /**
+     * @var PropertyIdSaturator
+     */
+    private $saturator;
+
+    public function __construct(
+        Connection $db,
+        PropertyIdSaturator $saturator
+    )
+    {
+        $this->db = $db;
+        $this->saturator = $saturator;
+    }
+
+    public function attach(SharedEventManagerInterface $events, $priority = 100)
+    {
+        $events->attach('*', 'iiif.manifest.view', [$this, 'viewManifest']);
+    }
+
+    public function viewManifest(Event $event) {
+        try {
+            /** @var ViewModel $viewModel */
+            $viewModel = $event->getParam('viewModel');
+
+            /** @var ManifestRepresentation $manifest */
+            $manifest = $viewModel->getVariable('resource');
+
+            $manifestId = $manifest->getOmekaId();
+            if (!$manifestId) {
+                return;
+            }
+            $result = $this->db->executeQuery(self::$GET_STATS, [
+                'hasCanvases' => $this->saturator->loadPropertyId('sc:hasCanvases'),
+                'manifestId' => $manifestId
+            ]);
+
+            $map = [];
+            foreach ($result->fetchAll() as $row) {
+                $map[(string)$row['canvas_id']] = $row;
+            }
+
+            $model = $manifest->getManifest();
+            foreach ($model->getCanvases() as $canvas) {
+                $source = $canvas->getSource();
+                $omekaId = $source['o:id'] ?? null;
+
+                if ($omekaId && $map[(string)$omekaId] ?? null) {
+                    $stats = $map[(string)$omekaId];
+                    $incomplete = $stats['incomplete_count'] ?: 0;
+                    $complete = $stats['complete_count'] ?: 0;
+                    $bookmarks = $stats['bookmarks'] ?: 0;
+
+                    $canvas->addMetaData([
+                        'edited' => $incomplete,
+                        'completed' => $complete > 0 && $incomplete === 0,
+                        'totalBookmarks' => $bookmarks,
+                    ]);
+                }
+            }
+        } catch (Throwable $exception) {
+            error_log($exception->getMessage());
+        }
+    }
+}

--- a/repos/public-user/src/Subscriber/PreDeleteCanvasSubscriber.php
+++ b/repos/public-user/src/Subscriber/PreDeleteCanvasSubscriber.php
@@ -1,0 +1,100 @@
+<?php
+
+
+namespace PublicUser\Subscriber;
+
+use Doctrine\DBAL\Connection;
+use Omeka\Api\Adapter\ItemAdapter;
+use Omeka\Api\Request;
+use Throwable;
+use Zend\EventManager\Event;
+use Zend\EventManager\SharedEventManagerInterface;
+use Zend\Log\Logger;
+
+class PreDeleteCanvasSubscriber
+{
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var Connection
+     */
+    private $db;
+
+    private static $SELECT_SQL = <<<SQL
+    SELECT * FROM user_canvas_mapping WHERE canvas_mapping_id=:canvasId
+SQL;
+
+
+
+    /**
+     * SQL query that will insert/update statistics for a given user and canvas.
+     *
+     * @var string
+     */
+    private static $DELETE_SQL = <<<SQL
+    DELETE FROM user_canvas_mapping WHERE canvas_mapping_id=:canvasId
+SQL;
+
+    public function __construct(
+        Logger $logger,
+        Connection $db
+    )
+    {
+        $this->logger = $logger;
+        $this->db = $db;
+    }
+
+    public function attach(SharedEventManagerInterface $events)
+    {
+
+        $events->attach(
+            ItemAdapter::class,
+            'api.delete.pre',
+            [$this, 'handleDelete'],
+            -1000
+        );
+    }
+
+    /**
+     * @param Event $event
+     * @throws Throwable
+     */
+    public function handleDelete(Event $event)
+    {
+        $this->logger->notice(implode(' : ', array_keys($event->getParams())));
+        /** @var Request $request */
+        $request = $event->getParam('request');
+        $id = $request->getId();
+
+        $results = $this->db->executeQuery(self::$SELECT_SQL, [
+            'canvasId' => $id,
+        ]);
+
+        if ($results->rowCount()) {
+            try {
+                $this->db->beginTransaction();
+                $update = $this->db->executeUpdate(self::$DELETE_SQL, [
+                    'canvasId' => $id
+                ]);
+
+                $this->logger->log(Logger::INFO, 'Removed user canvases', [
+                    'canvasId' => $id,
+                    'result' => $update,
+                ]);
+
+                $this->db->commit();
+            } catch (Throwable $ex) {
+                $this->logger->log(Logger::WARN, 'Could not remove user mapping', [
+                    'canvasId' => $id,
+                    'error' => (string)$ex,
+                ]);
+                $this->db->rollBack();
+            }
+        }
+
+    }
+
+}

--- a/repos/public-user/view/public-user/account/profile.twig
+++ b/repos/public-user/view/public-user/account/profile.twig
@@ -1,5 +1,8 @@
+{% do headLink().prependStylesheet(assetUrl('css/statistics.css', 'PublicUser')) %}
 {% set theForm = form.prepare() %}
 {% set sectionNavs = {'user-information': translate('User information'), 'change-password': translate('Password')} %}
+
+
 
 {{ pageTitle(translate('Edit User: {user}')|replace({'{user}': user.getName()})) | raw }}
 {{ trigger('view.edit.before') }}
@@ -8,12 +11,26 @@
 
     {{ trigger('view.edit.form.before', {'form': form }) }}
 
+{% if statistics %}
+    <div class="c-collection__statistics">
+        <div class="c-statistics">
+            {% for statistic in statistics %}
+                <dl class="c-statistic c-statistic--sm">
+                    <dt>{{ statistic.label }}</dt>
+                    <dd>{{ statistic.value }}</dd>
+                </dl>
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}
+
 <fieldset id="user-information" class="section active">
     {{ formCollection(form.get('user-information'), false) }}
 </fieldset>
 <fieldset id="change-password" class="section">
     {{ formCollection(form.get('change-password'), false) }}
 </fieldset>
+
 
 {{ trigger('view.edit.form.after', {'form': form }) }}
 <div id="page-actions">
@@ -23,17 +40,3 @@
 {{ formElement(form.get('csrf')) }}
 {{ form().closeTag()| raw }}
 {{ trigger('view.edit.after') }}
-
-
-{% if(manifest.statistics) %}
-    <div class="c-collection__statistics">
-        <div class="c-statistics ">
-            {% for statistic in manifest.statistics %}
-                <dl class="c-statistic c-statistic--sm c-statistic--inline">
-                    <dt>{{ manifest.statistics.label }}</dt>
-                    <dd>{{ manifest.statistics.value }}</dd>
-                </dl>
-            {% endfor %}
-        </div>
-    </div>
-{% endif %}

--- a/repos/search/Module.php
+++ b/repos/search/Module.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace MadocSearch;
+
+use Digirati\OmekaShared\ModuleExtensions\ConfigurationFormAutoloader;
+use Omeka\Module\AbstractModule;
+use Omeka\Permissions\Acl;
+use MadocSearch\Admin\ConfigurationForm;
+use Zend\Config\Factory;
+use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Zend\Mvc\MvcEvent;
+
+class Module extends AbstractModule implements ConfigProviderInterface
+{
+    use ConfigurationFormAutoloader;
+
+    private $config;
+
+    public function getConfig()
+    {
+        if ($this->config) {
+            return $this->config;
+        }
+
+        // Load our configuration.
+        $this->config = Factory::fromFiles(
+            glob(__DIR__ . '/config/*.config.*')
+        );
+
+        return $this->config;
+    }
+
+    public function onBootstrap(MvcEvent $event)
+    {
+        parent::onBootstrap($event);
+
+        /** @var Acl $acl */
+        $acl = $this->getServiceLocator()->get('Omeka\Acl');
+        $acl->allow(
+            null,
+            []
+        );
+    }
+
+    function getConfigFormClass(): string
+    {
+        return ConfigurationForm::class;
+    }
+}

--- a/repos/search/Module.php
+++ b/repos/search/Module.php
@@ -93,11 +93,21 @@ class Module extends AbstractModule implements ConfigProviderInterface
                         $annotationUri->setScheme($internalAnnotationServerUri->getScheme());
                     }
 
+                    // Special case for part-of
+                    $partOf = is_array($annotation['target']) ? $annotation['target']['dcterms:isPartOf']['id'] ?? '' : '';
+                    $partOfUri = $partOf ? new Uri($partOf) : null;
+                    if ($partOfUri && $partOfUri->getHost() === $mainSiteUri->getHost() && $internalOmekaServer) {
+                        $partOfUri->setHost($internalOmekaServerUri->getHost());
+                        $partOfUri->setPort($internalOmekaServerUri->getPort());
+                        $partOfUri->setScheme($internalOmekaServerUri->getScheme());
+                    }
+
                     $url = new Uri($annotationIndexer);
                     $url->setPath('/index-annotation');
                     $url->setQuery([
                         'annotation' => $annotationUri->toString(),
                         'capture_model' => $generator->toString(),
+                        'manifest' => $partOfUri ? $partOfUri->toString() : '',
                     ]);
 
                     $client = new Client();

--- a/repos/search/asset/css/statistics.css
+++ b/repos/search/asset/css/statistics.css
@@ -1,0 +1,110 @@
+.c-statistics {
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: row;
+    flex-direction: row;
+}
+
+.c-statistics--center {
+    -ms-flex-pack: center;
+    justify-content: center;
+}
+
+.c-statistic {
+    font-size: 14px;
+    display: -ms-flexbox;
+    display: flex;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -ms-flex-pack: top;
+    justify-content: top;
+    -ms-flex-align: center;
+    align-items: center;
+    margin: 0;
+    text-align: center;
+    padding: 15px 20px;
+    min-width: 0;
+}
+
+.c-statistic:after {
+    clear: both;
+    content: "";
+    display: table;
+}
+
+.c-statistic:hover {
+    background-color: #f2f3f4;
+}
+
+.c-statistic dd {
+    color: inherit;
+    font-family: "Lato", Arial, "Helvetica Neue", Helvetica, sans-serif;
+    font-weight: 600;
+    line-height: 1.3;
+    margin: 0.6em 0;
+    padding: 0;
+    margin: 0;
+    font-size: 1.2em;
+    -ms-flex-order: 0;
+    order: 0;
+    margin: 0;
+}
+
+.c-statistic dt {
+    -ms-flex-order: 1;
+    order: 1;
+}
+
+.c-statistic--inline {
+    -ms-flex-direction: row;
+    flex-direction: row;
+    padding: 0 15px;
+}
+
+.c-statistic--inline dd {
+    padding-right: 7px;
+}
+
+.c-statistic--sm dd {
+    font-size: 2em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--sm dd {
+        font-size: 1.4em;
+    }
+}
+
+.c-statistic--md dd {
+    font-size: 3em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--md dd {
+        font-size: 2em;
+    }
+}
+
+.c-statistic--lg dd {
+    font-size: 4em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--lg dd {
+        font-size: 3em;
+    }
+}
+
+.c-statistic--xl {
+    padding: 15px 40px;
+}
+
+.c-statistic--xl dd {
+    font-size: 6em;
+}
+
+@media (max-width: 1024px) {
+    .c-statistic--xl dd {
+        font-size: 4em;
+    }
+}

--- a/repos/search/composer.json
+++ b/repos/search/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "digirati/madoc-search-module",
+  "license": "MIT",
+  "version": "1.0.0",
+  "description": "Omeka Search module",
+  "type": "omeka-s-module",
+  "require": {
+    "digirati/omeka-shared": "~1.0.0",
+    "php": ">=7.0"
+  },
+  "autoload": {
+    "psr-4": {"MadocSearch\\": "src"}
+  },
+  "extra": {
+    "install-name": "MadocSearch"
+  }
+}

--- a/repos/search/config/module.config.php
+++ b/repos/search/config/module.config.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'view_manager' => [
+        'template_path_stack' => [
+            realpath(__DIR__.'/../view'),
+        ],
+    ],
+];

--- a/repos/search/config/module.ini
+++ b/repos/search/config/module.ini
@@ -1,0 +1,9 @@
+[info]
+name         = "Madoc Search Module"
+version      = "1.0.0"
+author       = "Digirati"
+configurable = true
+description  = "Omeka search module, enhanced using elastic-search"
+module_link  = "https://github.com/digirati-co-uk/madoc-platform/tree/master/repos/search"
+author_link  = "https://github.com/digirati-co-uk"
+omeka_version_constraint = "^1.3.0"

--- a/repos/search/config/service.config.php
+++ b/repos/search/config/service.config.php
@@ -1,0 +1,36 @@
+<?php
+
+
+use Digirati\OmekaShared\Factory\LocaleHelperFactory;
+use Digirati\OmekaShared\Framework\PageBlockMediaAdapter;
+use Digirati\OmekaShared\Helper\LocaleHelper;
+use MadocSearch\Media\AnnotationStatisticsIngester;
+use MadocSearch\Media\AnnotationStatisticsRenderer;
+use Psr\Container\ContainerInterface;
+
+return [
+    'service_manager' => [
+        'factories' => [
+            LocaleHelper::class => LocaleHelperFactory::class,
+            AnnotationStatisticsIngester::class => function () {
+                return new AnnotationStatisticsIngester();
+            },
+            AnnotationStatisticsRenderer::class => function (ContainerInterface $c) {
+                return new AnnotationStatisticsRenderer(
+                    $c->get('ZfcTwig\View\TwigRenderer')
+                );
+            },
+        ],
+    ],
+    'block_layouts' => [
+        'factories' => [
+            'annotation-statistics' => function (ContainerInterface $c) {
+                return new PageBlockMediaAdapter(
+                    $c->get(AnnotationStatisticsIngester::class),
+                    $c->get(AnnotationStatisticsRenderer::class),
+                    $c->get(LocaleHelper::class)
+                );
+            }
+        ],
+    ],
+];

--- a/repos/search/src/Admin/ConfigurationForm.php
+++ b/repos/search/src/Admin/ConfigurationForm.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MadocSearch\Admin;
+
+use Digirati\OmekaShared\Framework\AbstractConfigurationForm;
+use Zend\Form\Element;
+
+class ConfigurationForm extends AbstractConfigurationForm {
+
+    static protected function getSettingsNamespace(): string
+    {
+        return 'omeka-search';
+    }
+
+    protected function getFormFields(): array
+    {
+        return [
+            'enable-item-search' => (new Element\Checkbox())
+                ->setOptions([
+                    'label' => 'Enable item search', // @translate
+                    'info' => 'When enabled, the search will return Omeka items', // @translate
+                ])
+                ->setAttribute('required', true),
+        ];
+    }
+}

--- a/repos/search/src/Media/AnnotationStatisticsIngester.php
+++ b/repos/search/src/Media/AnnotationStatisticsIngester.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MadocSearch\Media;
+
+use Digirati\OmekaShared\Framework\AbstractIngester;
+use Omeka\Media\Ingester\IngesterInterface;
+use Zend\Form\Element;
+
+class AnnotationStatisticsIngester extends AbstractIngester implements IngesterInterface
+{
+
+    /**
+     * @param string $operation either "create" or "update"
+     * @return Element[]
+     */
+    public function getFormElements(string $operation): array
+    {
+        return [];
+    }
+
+    /**
+     * Get a human-readable label for this ingester.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return 'Annotation statistics';
+    }
+
+    /**
+     * Get the name of the renderer for media ingested by this ingester
+     *
+     * @return string
+     */
+    public function getRenderer()
+    {
+        return 'annotation-statistics';
+    }
+}

--- a/repos/search/src/Media/AnnotationStatisticsRenderer.php
+++ b/repos/search/src/Media/AnnotationStatisticsRenderer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MadocSearch\Media;
+
+use Omeka\Media\Renderer\RendererInterface;
+
+class AnnotationStatisticsRenderer implements RendererInterface
+{
+
+}

--- a/repos/search/src/Media/AnnotationStatisticsRenderer.php
+++ b/repos/search/src/Media/AnnotationStatisticsRenderer.php
@@ -2,9 +2,73 @@
 
 namespace MadocSearch\Media;
 
-use Omeka\Media\Renderer\RendererInterface;
 
-class AnnotationStatisticsRenderer implements RendererInterface
+use Digirati\OmekaShared\Framework\MediaPageBlockDualRender;
+use Digirati\OmekaShared\Framework\RenderMedia;
+use GuzzleHttp\Client;
+use Omeka\Api\Representation\SitePageBlockRepresentation;
+use Zend\View\Model\ViewModel;
+use Zend\View\Renderer\PhpRenderer;
+use ZfcTwig\View\TwigRenderer;
+
+class AnnotationStatisticsRenderer implements MediaPageBlockDualRender
 {
+    use RenderMedia;
 
+    /**
+     * @var TwigRenderer
+     */
+    private $twig;
+
+    public function __construct(
+        TwigRenderer $twig
+    ) {
+        $this->twig = $twig;
+    }
+
+    public function renderFromData(PhpRenderer $view, array $data, array $options = [])
+    {
+        try {
+            /////// This is to demonstrate the Search indexing.
+            $es = getenv('OMEKA__SEARCH_ELASTICSEARCH');
+            $index = getenv('OMEKA__ANNOTATION_ES_INDEX');
+            if (!$es || !$index) {
+                return '';
+            }
+
+            $client = new Client(['base_uri' => $es]);
+            $resp = $client->post("/$index/_search", [
+                'headers' => [
+                    'Content-Type' => 'application/json'
+                ],
+                'body' => json_encode([
+                    "size" => 0,
+                    "aggs" => [
+                        "distinct_canvases" => [
+                            "cardinality" => [
+                                "field" => "uri.keyword"
+                            ]
+                        ]
+                    ]
+                ]),
+            ]);
+
+            $json = json_decode($resp->getBody()->getContents(), true);
+            $vm = new ViewModel([
+                'totalAnnotations' => $json['hits']['total'] ?? 0,
+                'totalImages' => $json['aggregations']['distinct_canvases']['value'] ?? 0,
+            ]);
+
+            $vm->setTemplate('madoc-search/media/annotation-statistics');
+
+            return $this->twig->render($vm);
+        } catch (\Throwable $e) {
+            return '';
+        }
+    }
+
+    public function pageBlockOptions(SitePageBlockRepresentation $pageBlock): array
+    {
+        return [];
+    }
 }

--- a/repos/search/view/madoc-search/media/annotation-statistics.twig
+++ b/repos/search/view/madoc-search/media/annotation-statistics.twig
@@ -1,0 +1,12 @@
+{% do headLink().prependStylesheet(assetUrl('css/statistics.css', 'MadocSearch')) %}
+
+<div class="c-statistics c-statistics--center">
+    <dl class="c-statistic c-statistic--xl">
+        <dt>Images annotated</dt>
+        <dd>{{ totalImages }}</dd>
+    </dl>
+    <dl class="c-statistic c-statistic--xl">
+        <dt>Annotations</dt>
+        <dd>{{ totalAnnotations }}</dd>
+    </dl>
+</div>

--- a/repos/shared-library/src/Factory/PropertyIdSaturatorFactory.php
+++ b/repos/shared-library/src/Factory/PropertyIdSaturatorFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Digirati\OmekaShared\Factory;
+
+
+use Digirati\OmekaShared\Utility\PropertyIdSaturator;
+use Psr\Container\ContainerInterface;
+
+class PropertyIdSaturatorFactory
+{
+    public function __invoke(ContainerInterface $c)
+    {
+        return new PropertyIdSaturator($c->get('Omeka\ApiManager'));
+    }
+}

--- a/repos/shared-library/src/Framework/AbstractIngester.php
+++ b/repos/shared-library/src/Framework/AbstractIngester.php
@@ -1,8 +1,6 @@
 <?php
 
-
-namespace IIIFStorage\Media;
-
+namespace Digirati\OmekaShared\Framework;
 
 use Locale;
 use Omeka\Api\Representation\MediaRepresentation;
@@ -182,3 +180,4 @@ abstract class AbstractIngester implements MutableIngesterInterface
         );
     }
 }
+

--- a/repos/shared-library/src/Framework/LocalisedMedia.php
+++ b/repos/shared-library/src/Framework/LocalisedMedia.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace IIIFStorage\Media;
+namespace Digirati\OmekaShared\Framework;
 
 
 interface LocalisedMedia
 {
     public function getLang(): string;
 }
+

--- a/repos/shared-library/src/Framework/MediaPageBlockDualRender.php
+++ b/repos/shared-library/src/Framework/MediaPageBlockDualRender.php
@@ -1,8 +1,6 @@
 <?php
 
-
-namespace IIIFStorage\Media;
-
+namespace Digirati\OmekaShared\Framework;
 
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Media\Renderer\RendererInterface;

--- a/repos/shared-library/src/Framework/PageBlockMediaAdapter.php
+++ b/repos/shared-library/src/Framework/PageBlockMediaAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace IIIFStorage\Media;
+namespace Digirati\OmekaShared\Framework;
 
 use Digirati\OmekaShared\Helper\LocaleHelper;
 use Digirati\OmekaShared\Utility\OmekaValue;

--- a/repos/shared-library/src/Framework/RenderMedia.php
+++ b/repos/shared-library/src/Framework/RenderMedia.php
@@ -1,8 +1,6 @@
 <?php
 
-
-namespace IIIFStorage\Media;
-
+namespace Digirati\OmekaShared\Framework;
 
 use Digirati\OmekaShared\Utility\OmekaValue;
 use Omeka\Api\Representation\MediaRepresentation;
@@ -43,7 +41,11 @@ trait RenderMedia
             }
         }
 
-        return $this->renderFromData($view, $data, $options);
+        if ($this instanceof MediaPageBlockDualRender) {
+            return $this->renderFromData($view, $data, $options);
+        }
+
+        return '';
     }
 
     public function getCurrentMedia()

--- a/repos/shared-library/src/Framework/TranslatableRenderer.php
+++ b/repos/shared-library/src/Framework/TranslatableRenderer.php
@@ -1,7 +1,6 @@
 <?php
 
-namespace IIIFStorage\Media;
-
+namespace Digirati\OmekaShared\Framework;
 
 interface TranslatableRenderer
 {

--- a/repos/shared-library/src/Model/MediaValue.php
+++ b/repos/shared-library/src/Model/MediaValue.php
@@ -29,13 +29,14 @@ class MediaValue implements ValueInterface
         $this->isPublic = $isPublic;
     }
 
-    public static function IIIFImage(string $url, string $label)
+    public static function IIIFImage(string $url, string $label, string $thumbnailUrl = null)
     {
         return new static(
             $url,
             'iiif',
             [
-                FieldValue::literal('dcterms:title', 'Title', $label)
+                FieldValue::literal('dcterms:title', 'Title', $label),
+                'thumbnail-url' => $thumbnailUrl,
             ]
         );
     }

--- a/repos/shared-library/src/Model/MediaValue.php
+++ b/repos/shared-library/src/Model/MediaValue.php
@@ -47,9 +47,8 @@ class MediaValue implements ValueInterface
             'iiif',
             [
                 FieldValue::literal('dcterms:title', 'Title', $label),
-                FieldValue::literal('thumbnail-service', 'Thumbnail service', $thumbnailService),
-                // import at 512, although this should come from config, currently importing the largest.
-                FieldValue::literal('thumbnail-size', 'Thumbnail size', 512),
+                'thumbnail-service' => $thumbnailService,
+                'thumbnail-size' => 512,
             ]
         );
     }
@@ -72,8 +71,12 @@ class MediaValue implements ValueInterface
         $mediaItem['o:source'] = $this->source;
         $mediaItem['o:ingester'] = $this->ingester;
 
-        foreach ($this->values as $value) {
-            $mediaItem[$value->getTerm()] = $value->export();
+        foreach ($this->values as $key => $value) {
+            if ($value instanceof FieldValue) {
+                $mediaItem[$value->getTerm()] = $value->export();
+            } else {
+                $mediaItem[$key] = $value;
+            }
         }
 
         return $mediaItem;

--- a/repos/shared-library/src/Model/MediaValue.php
+++ b/repos/shared-library/src/Model/MediaValue.php
@@ -48,6 +48,8 @@ class MediaValue implements ValueInterface
             [
                 FieldValue::literal('dcterms:title', 'Title', $label),
                 FieldValue::literal('thumbnail-service', 'Thumbnail service', $thumbnailService),
+                // import at 512, although this should come from config, currently importing the largest.
+                FieldValue::literal('thumbnail-size', 'Thumbnail size', 512),
             ]
         );
     }

--- a/translations/madoc/template.pot
+++ b/translations/madoc/template.pot
@@ -6,166 +6,244 @@ msgstr ""
 
 msgid "Loading"
 msgstr ""
+
 msgid "User submitted annotations"
 msgstr ""
+
 msgid "These are annotations created by the community and may need extra work to complete."
 msgstr ""
+
 msgid "No annotations currently"
 msgstr ""
+
 msgid "wants to use your Omeka account"
 msgstr ""
+
 msgid "Update your profile"
 msgstr ""
+
 msgid "User information"
 msgstr ""
+
 msgid "Password"
 msgstr ""
+
 msgid "Edit User: {user}"
 msgstr ""
+
 msgid "Save"
 msgstr ""
+
 msgid "Thank you for registering"
 msgstr ""
+
 msgid "Forgot password"
 msgstr ""
+
 msgid "Login"
 msgstr ""
+
 msgid "Forgot password?"
 msgstr ""
+
 msgid "Register"
 msgstr ""
+
 msgid "Latest annotated images"
 msgstr ""
+
 msgid "Flag content"
 msgstr ""
+
 msgid "Thanks for flagging."
 msgstr ""
+
 msgid "Back to page"
 msgstr ""
+
 msgid "Back to item"
 msgstr ""
+
 msgid "Join the conversation"
 msgstr ""
+
 msgid "Import Annotation"
 msgstr ""
+
 msgid "No search results"
 msgstr ""
+
 msgid "Search the collection"
 msgstr ""
+
 msgid "Search"
 msgstr ""
+
 msgid "There are no linked resources for this item."
 msgstr ""
+
 msgid "Generating inline json for ID"
 msgstr ""
+
 msgid "Import A Capture Model from Json or Yaml"
 msgstr ""
+
 msgid "Next"
 msgstr ""
+
 msgid "Processing"
 msgstr ""
+
 msgid "Job has started with ID"
 msgstr ""
+
 msgid "View details at"
 msgstr ""
+
 msgid "View Log at"
 msgstr ""
+
 msgid "Bookmarking"
 msgstr ""
+
 msgid "Sorry, there was a problem saving your bookmark, please contact your site administrator."
 msgstr ""
+
 msgid "Go back to page"
 msgstr ""
+
 msgid "Synchronizing"
 msgstr ""
+
 msgid "Your resource translations are now being synchronized.  This could take a few minutes depending on the number of jobs\nrunning and the amount of resources to synchronize."
 msgstr ""
+
 msgid "Go to jobs"
 msgstr ""
+
 msgid "Synchronize translations"
 msgstr ""
+
 msgid "Are you sure?"
 msgstr ""
+
 msgid "Clicking Submit will dispatch jobs that will resynchronize localization resources\n    for all applicable Omeka content.  Synchronization may take some time"
 msgstr ""
+
 msgid "Submit"
 msgstr ""
+
 msgid "Please enable and configure Transifex to enable sync."
 msgstr ""
+
 msgid "Back to all groups"
 msgstr ""
+
 msgid "translations"
 msgstr ""
+
 msgid "Key"
 msgstr ""
+
 msgid "Message"
 msgstr ""
+
 msgid "Actions"
 msgstr ""
+
 msgid "Download template"
 msgstr ""
+
 msgid "View translatable strings"
 msgstr ""
+
 msgid "Where to add translations"
 msgstr ""
+
 msgid "view"
 msgstr ""
+
 msgid "No languages added yet."
 msgstr ""
+
 msgid "Can't find the language you're looking for?"
 msgstr ""
+
 msgid "Translations"
 msgstr ""
+
 msgid "Global translations"
 msgstr ""
+
 msgid "view all images"
 msgstr ""
-msgid "images"
-msgstr ""
+
 msgid "Previous Image"
 msgstr ""
+
 msgid "Next Image"
 msgstr ""
+
 msgid "Flag as inappropriate"
 msgstr ""
+
 msgid "Editing complete"
 msgstr ""
+
 msgid "Editing started"
 msgstr ""
+
 msgid "Editing not started"
 msgstr ""
+
 msgid "Changes to this page"
 msgstr ""
+
 msgid "Scroll carousel left"
 msgstr ""
+
 msgid "Scroll carousel right"
 msgstr ""
+
 msgid "Completed"
 msgstr ""
+
 msgid "Edited"
 msgstr ""
+
 msgid "Not started"
 msgstr ""
+
 msgid "Bookmarked"
 msgstr ""
+
 msgid "View activity"
 msgstr ""
+
 msgid "All collections"
 msgstr ""
+
 msgid "Image"
 msgstr ""
+
 msgid "Mark as complete"
 msgstr ""
+
+msgid "This page needs more work"
+msgstr ""
+
 msgid "Is this page complete?"
 msgstr ""
+
 msgid "This page has been marked as completed.<br/>\n                        You can mark as incomplete if it needs more work."
 msgstr ""
+
 msgid "Marking this page as complete helps us to understand the progress of annotations."
 msgstr ""
-msgid "Page marked as complete"
-msgstr ""
+
 msgid "View all images"
 msgstr ""
+
 msgid "Google Analytics tracking code"
 msgstr ""
 msgid "The tracking code to be used in Google Analytics tracking snippets"
@@ -201,6 +279,14 @@ msgstr ""
 msgid "Static elucidate"
 msgstr ""
 msgid "A full URL to an external elucidate to use for this site"
+msgstr ""
+msgid "Annotation studio version"
+msgstr ""
+msgid "The version of the Javascript to use. NOTE: Older versions may not work with this module."
+msgstr ""
+msgid "Debug mode"
+msgstr ""
+msgid "This should never be run in production and is for testing only."
 msgstr ""
 msgid "Use Open Seadragon as the viewer"
 msgstr ""
@@ -422,6 +508,10 @@ msgid "Add directly to site after importing"
 msgstr ""
 msgid "Bookmark"
 msgstr ""
+msgid "Enable item search"
+msgstr ""
+msgid "When enabled, the search will return Omeka items"
+msgstr ""
 msgid "Translations"
 msgstr ""
 msgid "Multi-lingual site"
@@ -461,6 +551,58 @@ msgstr ""
 msgid "Create IIIF Manifest"
 msgstr ""
 msgid "Create IIIF Canvas"
+msgstr ""
+msgid "Use carousel on collection page"
+msgstr ""
+msgid "When viewing a collection of manifests, show each manifest as a carousel, instead of a single thumbnail. NOTE: this will request more canvases and may slow down page, consider reducing the manifests per page below."
+msgstr ""
+msgid "Use original IDs"
+msgstr ""
+msgid "By default, "
+msgstr ""
+msgid "Collections per page"
+msgstr ""
+msgid "Amount of collections to view on top level collection per page"
+msgstr ""
+msgid "Manifests per collection"
+msgstr ""
+msgid "Amount of manifests to show per collection"
+msgstr ""
+msgid "Manifests per page"
+msgstr ""
+msgid "Amount of manifests to view on a collection per page"
+msgstr ""
+msgid "Canvases per page"
+msgstr ""
+msgid "Amount of canvases to view on a manifest per page"
+msgstr ""
+msgid "IIIF Storage options"
+msgstr ""
+msgid "Enable bookmarking"
+msgstr ""
+msgid "Allows logged in users to bookmark IIIF canvases"
+msgstr ""
+msgid "Enable mark as complete"
+msgstr ""
+msgid "Allows users to mark a page as complete, allowing no further annotations"
+msgstr ""
+msgid "Enable user created annotations"
+msgstr ""
+msgid "Allows users to create annotations"
+msgstr ""
+msgid "Enable user flagging"
+msgstr ""
+msgid "Allows users to flag content (requires backend service)"
+msgstr ""
+msgid "Enable users to see annotations"
+msgstr ""
+msgid "Allows users to see created annotations"
+msgstr ""
+msgid "Show single collection"
+msgstr ""
+msgid "By default if there is only one collection, the collection list will redirect to this. This option will disable that behaviour"
+msgstr ""
+msgid "Crowd sourcing"
 msgstr ""
 msgid "Manifests"
 msgstr ""


### PR DESCRIPTION
This is an initial release of the search module, adding in elasticsearch, and indexer and a retriever that will allow annotations created on the platform to be surfaced in Madoc. 

This work is the foundation for that, adding the required services to get up and running, with a quick example usage of these statistics in the new search module (not enabled by default on installations).

- Added `OMEKA__INTERNAL_URL` environment variable for internal network requests
- Added `OMEKA__ANNOTATION_INDEXER` environment variable for annotation indexer service
- Added `OMEKA__SEARCH_ELASTICSEARCH` environment variable for elasticsearch service
- Added `OMEKA__ANNOTATION_ES_INDEX` environment variables for annotation indexer service
- Added `OMEKA__SEARCH_INDEXER` environment variable for search indexer
- Added elasticsearch to base docker compose
- Added [Jane Founda](https://github.com/digirati-co-uk/jane-founda) IIIF Search service
- Added [Madoc Indexer](https://github.com/digirati-co-uk/madoc_draft_indexer) service
- Added constraints to thumbnail size with customisable import options (1000px max)
- Added final case for partOf that matches original id
- Added extra check for manifest when only canvas is provided
- Added simple statistics module, talking to Elasticsearch
- Added option for static thumbnail URL
- Added logging of duplicate Omeka IDs when requesting manifests
- Added expensive option for resolving Omeka ID from IIIF resource ID
- Added warning for admin users when they are on a duplicated manifest page
- Added manifest statistics subscriber to track statistics
- Added new Search Omeka module to index created annotations in Elasticsearch
- Added annotation statistics age block, powered by Elasticsearch
- Fixed stale docker images on CI
- Fixed default locale on Annotation Studio (en)
- Fixed missing styles for in-progress crowd-sourcing pages
- Fixed error during import of images with thumbnails (thumbnail image service)
- Fixed error when duplicate canvases where imported into single manifest
- Moved media helpers to shared modules
- Fixed unhandled exception in top contributor page block