### PR TITLE
Pre-release build

### DIFF
--- a/.travis/pre-release.sh
+++ b/.travis/pre-release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Next version from input
+NEXT_VERSION=$1;shift;
+
+# Create short commit hash for tagging.
+COMMIT_HASH="$(git rev-parse --short HEAD)"
+
+echo "Building v$NEXT_VERSION-$COMMIT_HASH";
+
+# Build.
+docker build -t madoc-platform-prerelease .
+
+# Tag.
+docker tag madoc-platform-prerelease:latest digirati/madoc-platform:v"$NEXT_VERSION"-"$COMMIT_HASH"
+echo -e
+echo -e "Successfully created and tagged: digirati/madoc-platform:v$NEXT_VERSION-$COMMIT_HASH";
+echo -e
+echo -e "  To push run:"
+echo -e "  $ docker push digirati/madoc-platform:v$NEXT_VERSION-$COMMIT_HASH"
+echo -e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added language switcher to the i18n module, available to be pulled into a theme
 - Added configurable Annotation Studio version allowing new versions to be selected and used without a deployment.
 - Added new hidden UI for administrating canvases which lets you re-ingest a thumbnail if it had previously failed.
+- Local tool (for now) to build pre-release docker tags, without creating a latest tag to be manually pushed to Dockerhub.
 
 ### Fixes
 - Fixed bug where canvas ID list may be only a single element


### PR DESCRIPTION
Local tool (for now) to build pre-release docker tags, without creating a latest tag to be manually pushed to Dockerhub.