### PR TITLE
Added theme builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ files/*
 translations/*.po~
 translations/s/*
 !translations/s/.gitkeep
+theme.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable Annotation Studio version allowing new versions to be selected and used without a deployment.
 - Added new hidden UI for administrating canvases which lets you re-ingest a thumbnail if it had previously failed.
 - Local tool (for now) to build pre-release docker tags, without creating a latest tag to be manually pushed to Dockerhub.
+- Added new CLI tool for getting all of the Madoc templates that can be added into a theme.
 
 ### Fixes
 - Fixed bug where canvas ID list may be only a single element

--- a/bin/theme-builder
+++ b/bin/theme-builder
@@ -1,0 +1,34 @@
+#!/usr/bin/env php
+<?php
+
+include __DIR__ . '/../vendor/autoload.php';
+
+$excludes = ['vendor', 'modules', 'themes'];
+
+$finder = new Symfony\Component\Finder\Finder;
+$finder->files()->in(__DIR__ . '/../repos')
+    ->name('*.twig')
+    ->name('*.phtml')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true)
+    ->exclude($excludes);
+
+
+$zip = new ZipArchive();
+
+if ($zip->open(__DIR__ . '/../theme.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+    foreach ($finder as $file) {
+        [$module, $path] = explode('/view/', $file->getRelativePath());
+        $modules[$module] = $modules[$module] ?? [];
+
+        $contents = $file->openFile();
+
+        $newPath = 'views/' . $path . '/' . $file->getFilename();
+
+        $zip->addFile($file->getRealPath(), $newPath);
+    }
+
+    $zip->close();
+} else {
+    echo "Could not create zip.";
+}


### PR DESCRIPTION
The theme builder will create a zip file of all of the `twig` and `.phtml` templates used in the project. The directory structure is important, but you can take a single file and put it into the same directory path in a custom theme to get up and running quickly.

You could also grab the entire theme and overwrite everything, but this will cause problems if the underlying templates update. A possible addition could be a diff-tool to check changes against an updated madoc. 

To run the tool:
```
bin/theme-builder
```

this create a `theme.zip` containing all of the theme files. You can unzip this and find the view folder which corresponds to a theme's view folder.