### PR TITLE
Transcriber role (case-sensitive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed inaccurate "total images" count on manifest snippet block
 - Fixed inaccurate "total images" count on manifest list by hiding it
 - Fixed inaccurate "total images" count on collections by hiding it
+- Fixed transcriber role issue
 
 ## [1.1.3](https://github.com/digirati-co-uk/madoc-platform/compare/v1.1.2...v1.1.3) - 2019-06-03
 

--- a/repos/public-user/Module.php
+++ b/repos/public-user/Module.php
@@ -135,8 +135,9 @@ class Module extends AbstractModule
         $this->addAclRules($event->getRouter(), $event->getRequest());
 
         $event->getRouteMatch();
+        /** @var \Omeka\Permissions\Acl $acl */
         $acl = $this->getServiceLocator()->get('Omeka\Acl');
-        $guest = new Role('transcriber');
+        $guest = new Role('Transcriber');
 
         $acl->addRole($guest);
         $acl->addRoleLabel('Transcriber', 'Transcriber');
@@ -370,7 +371,7 @@ class Module extends AbstractModule
         $acl = $serviceContainer->get('Omeka\Acl');
         $roles = $acl->getRoleLabels();
         // @todo fix when we get this.
-        $roles['transcriber'] = 'Transcriber';
+        $roles['Transcriber'] = 'Transcriber';
 
         $sharedEventManager->attach(SiteSettingsForm::class, 'form.add_elements', function (Event $event) use ($roles) {
             /** @var SiteSettingsForm $form */


### PR DESCRIPTION
This is a temporary fix. The issue is the case-sensitivity of the `Transcriber` role. This is an issue standing since before the open-source release. When creating or editing a user in the backend, the variation that is used is `Transcriber`, so this standardises on that. If you are having issues you can simply update the role from the backend.

Future steps:
* Change to case-insensitive version
* Write migration tool to change `Transcriber` to `transcriber`