### PR TITLE
Fixed bug when saving annotations from i18n site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixed annotation studio bug with multi-lingual sites and saving of annotations
 
 ## [1.2.5](https://github.com/digirati-co-uk/madoc-platform/compare/v1.2.4...v1.2.5)
 

--- a/repos/annotation-studio/Module.php
+++ b/repos/annotation-studio/Module.php
@@ -103,7 +103,7 @@ class Module extends AbstractModule
         $router = $this->getServiceLocator()->get(Router::class);
 
         if ($currentSite) {
-            $router->setSiteId($currentSite->id());
+            $router->setSiteId($currentSite->slug());
         }
 
         $moderation = $siteSettings->get('annotation-studio-moderation-status', '')

--- a/repos/annotation-studio/src/CaptureModel/CaptureModelRepository.php
+++ b/repos/annotation-studio/src/CaptureModel/CaptureModelRepository.php
@@ -41,10 +41,10 @@ class CaptureModelRepository
         $this->router = $router;
     }
     
-    public function setSiteId(string $id)
+    public function setSiteId(string $id, string $slug)
     {
         $this->siteId = $id;
-        $this->router->setSiteId($id);
+        $this->router->setSiteId($slug);
     }
 
     public function getPropertyByName(string $property)

--- a/repos/annotation-studio/src/CaptureModel/Router.php
+++ b/repos/annotation-studio/src/CaptureModel/Router.php
@@ -35,30 +35,48 @@ class Router
         $this->siteId = $id;
     }
 
-    public function component($component, $moderation, $site = false)
+    public function component($component, $moderation, $siteId = false)
     {
+
+        $options = [
+            'component' => $component,
+            'moderation' => $moderation,
+            'locale' => null,
+        ];
+        if ($siteId) {
+            $options['site-slug'] = $this->siteId;
+        }
+
+
+        error_log($this->url->create(
+            $this->getRoute('component', !!$siteId),
+            $options,
+            $this->getOptions()
+        ));
+
         return $this->url->create(
-            $this->getRoute('component', $site),
-            [
-                'component' => $component,
-                'moderation' => $moderation,
-            ],
-            $this->getOptions(),
-            $site
+            $this->getRoute('component', !!$siteId),
+            $options,
+            $this->getOptions()
         );
     }
 
-    public function model($model, $component, $moderation, $site = false)
+    public function model($model, $component, $moderation, $siteId = false)
     {
+        $options = [
+            'model' => $model,
+            'component' => $component,
+            'moderation' => $moderation,
+            'locale' => null,
+        ];
+        if ($this->siteId) {
+            $options['site-slug'] = $this->siteId;
+        }
+
         return $this->url->create(
-            $this->getRoute('model', $site),
-            [
-                'model' => $model,
-                'component' => $component,
-                'moderation' => $moderation,
-            ],
-            $this->getOptions(),
-            $site
+            $this->getRoute('model', !!$siteId),
+            $options,
+            $this->getOptions()
         );
     }
 

--- a/repos/annotation-studio/src/Controller/CaptureModelController.php
+++ b/repos/annotation-studio/src/Controller/CaptureModelController.php
@@ -116,8 +116,8 @@ class CaptureModelController extends AbstractPsr7ActionController
     {
         $site = $this->currentSite();
         if ($site) {
-            $this->router->setSiteId($site->id());
-            $this->repo->setSiteId($site->id());
+            $this->router->setSiteId($site->slug());
+            $this->repo->setSiteId($site->id(), $site->slug());
         }
     }
 


### PR DESCRIPTION
This stops capture models with `/en/` and `/cy/` being served.