### PR TITLE
Make root ebs size configurable via variable, default 30GiB

### DIFF
--- a/infrastructure/terraform/madoc/single-instance/ec2.tf
+++ b/infrastructure/terraform/madoc/single-instance/ec2.tf
@@ -85,6 +85,11 @@ resource "aws_instance" "madoc" {
   subnet_id = aws_subnet.public.id
   key_name  = aws_key_pair.auth.key_name
 
+  root_block_device {
+    volume_size = var.root_size
+    volume_type = "gp2"
+  }
+
   user_data = templatefile("./files/bootstrap_ec2.tmpl", { prefix = var.prefix, workspace = terraform.workspace, region = var.region })
 
   iam_instance_profile = aws_iam_instance_profile.madoc.name

--- a/infrastructure/terraform/madoc/single-instance/variables.tf
+++ b/infrastructure/terraform/madoc/single-instance/variables.tf
@@ -24,15 +24,21 @@ variable availability_zone {
   default     = "eu-west-1a"
 }
 
+variable root_size {
+  type        = number
+  description = "Size of root EBS volume, in GiB"
+  default     = 30
+}
+
 variable ebs_size {
   type        = number
-  description = "Size of EBS volume, in GB"
+  description = "Size of EBS data volume, in GiB"
   default     = 20
 }
 
 variable ebs_backup_size {
   type        = number
-  description = "Size of EBS backup volume, in GB"
+  description = "Size of EBS backup volume, in GiB"
   default     = 30
 }
 


### PR DESCRIPTION
By default TF sets root as 8GiB which doesn't leave much room.