### PR TITLE
Updated resource claims

### DIFF
--- a/services/madoc-ts/src/database/queries/resource-queries.ts
+++ b/services/madoc-ts/src/database/queries/resource-queries.ts
@@ -32,3 +32,28 @@ export function deleteResource(resource_id: number, resource_type: string, site_
           and site_id=${site_id}
   `;
 }
+
+export function getParentResources(resourceId: string, siteId: number, projectId?: string) {
+  if (projectId) {
+    return sql<{ resource_id: number }>`
+        select parent_resources.resource_id
+        from iiif_derived_resource_items parent_resources
+        left join iiif_derived_resource_items projectLinks on
+            parent_resources.resource_id = projectLinks.item_id
+        left join iiif_project project on
+            project.collection_id = projectLinks.resource_id
+        where parent_resources.item_id = ${resourceId}
+        and projectLinks.site_id = ${siteId}
+        and parent_resources.site_id = ${siteId}
+        and project.site_id = ${siteId}
+        and project.id = ${projectId}
+    `;
+  }
+
+  return sql<{ resource_id: number; item_id: number }>`
+      select resource_id, item_id 
+      from iiif_derived_resource_items 
+      where item_id = ${resourceId} 
+        and site_id = ${siteId} 
+  `;
+}

--- a/services/madoc-ts/src/gateway/api.ts
+++ b/services/madoc-ts/src/gateway/api.ts
@@ -409,6 +409,12 @@ export class ApiClient {
     return this.request<ManifestFull>(`/api/madoc/iiif/manifests/${id}${page ? `?page=${page}` : ''}`);
   }
 
+  async getManifestCollections(id: number, query?: { project_id?: number }) {
+    return this.request<{ collections: number[] }>(
+      `/api/madoc/iiif/manifests/${id}/collections${query ? `?${stringify(query)}` : ''}`
+    );
+  }
+
   async getCollectionMetadata(id: number) {
     return this.request<GetMetadata>(`/api/madoc/iiif/collections/${id}/metadata`);
   }
@@ -469,6 +475,12 @@ export class ApiClient {
   }
   async getCanvasById(id: number) {
     return this.request<CanvasFull>(`/api/madoc/iiif/canvases/${id}`);
+  }
+
+  async getCanvasManifests(id: number, query?: { project_id?: number }) {
+    return this.request<{ manifests: number[] }>(
+      `/api/madoc/iiif/canvases/${id}/manifests${query ? `?${stringify(query)}` : ''}`
+    );
   }
 
   // Capture model API.

--- a/services/madoc-ts/src/router.ts
+++ b/services/madoc-ts/src/router.ts
@@ -52,6 +52,8 @@ import { siteTopicType } from './routes/site/site-topic-type';
 import { siteTopicTypes } from './routes/site/site-topic-types';
 import { createResourceClaim } from './routes/projects/create-resource-claim';
 import { statistics } from './routes/iiif/statistics';
+import { getCanvasManifests } from './routes/iiif/canvases/get-canvas-manifests';
+import { getManifestCollections } from './routes/iiif/manifests/get-manifest-collections';
 
 export const router = new TypedRouter({
   // Normal route
@@ -105,6 +107,7 @@ export const router = new TypedRouter({
     updateManifestStructure,
     'UpdateStructureList',
   ],
+  'get-manifest-collections': [TypedRouter.GET, '/api/madoc/iiif/manifests/:id/collections', getManifestCollections],
   'get-manifest-autocomplete': [TypedRouter.GET, '/api/madoc/iiif/autocomplete/manifests', getManifestAutocomplete],
 
   // Canvas API
@@ -113,9 +116,10 @@ export const router = new TypedRouter({
   'create-canvas': [TypedRouter.POST, '/api/madoc/iiif/canvases', createCanvas],
   'get-canvas-metadata': [TypedRouter.GET, '/api/madoc/iiif/canvases/:id/metadata', getCanvasMetadata],
   'put-canvas-metadata': [TypedRouter.PUT, '/api/madoc/iiif/canvases/:id/metadata', updateMetadata, 'MetadataUpdate'],
+  'get-canvas-manifests': [TypedRouter.GET, '/api/madoc/iiif/canvases/:id/manifests', getCanvasManifests],
 
   // Import API
-  'import-manifest': [TypedRouter.POST, '/api/madoc/iiif/import/manifest', importManifest],
+  'import-manifest': [TypedRouter.POST, '/api/madoc/iiif/import/manifest' + '', importManifest],
   'import-collection': [TypedRouter.POST, '/api/madoc/iiif/import/collection', importCollection],
 
   // Stats.

--- a/services/madoc-ts/src/routes/iiif/canvases/get-canvas-manifests.ts
+++ b/services/madoc-ts/src/routes/iiif/canvases/get-canvas-manifests.ts
@@ -1,0 +1,13 @@
+import { RouteMiddleware } from '../../../types/route-middleware';
+import { optionalUserWithScope } from '../../../utility/user-with-scope';
+import { getParentResources } from '../../../database/queries/resource-queries';
+
+export const getCanvasManifests: RouteMiddleware<{ id: string }> = async context => {
+  const { siteId } = optionalUserWithScope(context, []);
+  const canvasId = context.params.id;
+  const projectId = context.query.project_id;
+
+  const results = await context.connection.any(getParentResources(canvasId, siteId, projectId));
+
+  context.response.body = { manifests: results.map(resource => resource.resource_id) };
+};

--- a/services/madoc-ts/src/routes/iiif/manifests/get-manifest-collections.ts
+++ b/services/madoc-ts/src/routes/iiif/manifests/get-manifest-collections.ts
@@ -1,0 +1,13 @@
+import { RouteMiddleware } from '../../../types/route-middleware';
+import { optionalUserWithScope } from '../../../utility/user-with-scope';
+import { getParentResources } from '../../../database/queries/resource-queries';
+
+export const getManifestCollections: RouteMiddleware = async context => {
+  const { siteId } = optionalUserWithScope(context, []);
+  const manifestId = context.params.id;
+  const projectId = context.query.project_id;
+
+  const results = await context.connection.any(getParentResources(manifestId, siteId, projectId));
+
+  context.response.body = { collections: results.map(resource => resource.resource_id) };
+};


### PR DESCRIPTION
When creating a resource claim, it will now try to fill in the blanks to ensure a consistent structure in the crowdsourcing task structure. If it's a canvas without a manifest or collection it will first look up all of the manifests that the canvas is in (in the same project) and if there's only one, it will use that. The same process for collections. This ensures that 99% of the time there is only one set of crowdsourcing tasks created in the UI.

2 new endpoints to enable this.

**Get manifests collections**
```
GET /api/madoc/iiif/manifests/123/collections
{
  "collections": [123, 456]
}
```

**Get canvas manifests**
```
GET /api/madoc/iiif/canvases/123/manifests
{
  "manifests": [123, 456]
}
```