### PR TITLE
Mirador / UV Search for annotations

### DIFF
--- a/.env
+++ b/.env
@@ -34,3 +34,5 @@ POSTGRES_MODELS_API_PASSWORD=models_api_password
 POSTGRES_CONFIG_SERVICE_USER=config_service
 POSTGRES_CONFIG_SERVICE_SCHEMA=config_service
 POSTGRES_CONFIG_SERVICE_PASSWORD=config_service_password
+
+GATEWAY_HOST=http://localhost:8888

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - ./services/tasks-api/lib:/home/node/app/lib
 
   model-api:
-    image: digirati/capture-models:v0.7.8
+    image: digirati/capture-models:v0.7.13
     environment:
       - SERVER_PORT=3000
       - DATABASE_HOST=shared-postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - OMEKA__URL=http://madoc
       - REDIS_HOST=gateway-redis
       - API_GATEWAY=http://gateway:8080
+      - GATEWAY_HOST=${GATEWAY_HOST}
       - OMEKA_FILE_DIRECTORY=/home/node/app/omeka-files
       - MIGRATE=true
     ports:

--- a/services/madoc-ts/src/gateway/api.ts
+++ b/services/madoc-ts/src/gateway/api.ts
@@ -31,6 +31,8 @@ import { ProjectListItem } from '../types/schemas/project-list-item';
 import { ProjectFull } from '../types/schemas/project-full';
 import { UserDetails } from '../types/schemas/user-details';
 import { CrowdsourcingReview } from './tasks/crowdsourcing-review';
+import { ModelSearch } from '../types/schemas/search';
+
 
 export class ApiClient {
   private readonly gateway: string;
@@ -522,6 +524,27 @@ export class ApiClient {
       method: 'PUT',
       body: captureModel,
     });
+  }
+
+  async searchPublishedModelFields(
+    target: { canvas?: string; manifest?: string; collection?: string },
+    query: string,
+    filters: {
+      field_type?: string;
+      selector_type?: string;
+      parent_property?: string;
+      capture_model_id?: string;
+    }
+  ) {
+    const queryString = {
+      ...target,
+      q: query,
+      ...filters,
+    };
+
+    return this.request<{
+      results: ModelSearch[];
+    }>(`/api/crowdsourcing/search/published?${stringify(queryString)}`);
   }
 
   async createCaptureModel(label: string) {

--- a/services/madoc-ts/src/router.ts
+++ b/services/madoc-ts/src/router.ts
@@ -64,6 +64,8 @@ import { addLinking } from './routes/iiif/linking/add-linking';
 import { deleteLinking } from './routes/iiif/linking/delete-linking';
 import { updateLinking } from './routes/iiif/linking/update-linking';
 import { getLinking } from './routes/iiif/linking/get-linking';
+import { searchManifest } from './routes/iiif/manifests/search-manifest';
+import { exportManifest } from './routes/iiif/manifests/export-manifest';
 
 export const router = new TypedRouter({
   // Normal route
@@ -182,6 +184,9 @@ export const router = new TypedRouter({
   'site-topic-type': [TypedRouter.GET, '/s/:slug/madoc/api/topics/:type', siteTopicType],
   'site-topic-types': [TypedRouter.GET, '/s/:slug/madoc/api/topics', siteTopicTypes],
   'site-published-models': [TypedRouter.GET, '/s/:slug/madoc/api/canvases/:id/models', sitePublishedModels],
+  // To be worked into API calling methods
+  'manifest-search': [TypedRouter.GET, '/s/:slug/madoc/api/manifests/:id/search/1.0', searchManifest],
+  'manifest-export': [TypedRouter.GET, '/s/:slug/madoc/api/manifests/:id/export/source', exportManifest],
 
   // PAT
   'personal-access-token': [TypedRouter.POST, '/api/madoc/access-token', personalAccessToken],

--- a/services/madoc-ts/src/routes/iiif/manifests/export-manifest.ts
+++ b/services/madoc-ts/src/routes/iiif/manifests/export-manifest.ts
@@ -1,0 +1,53 @@
+import { RouteMiddleware } from '../../../types/route-middleware';
+import { sql } from 'slonik';
+import * as fs from 'fs';
+
+const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
+
+export const exportManifest: RouteMiddleware<{ id: string; slug: string }> = async context => {
+  const manifestId = context.params.id;
+  const siteSlug = context.params.slug;
+
+  const file = await context.connection.one(
+    sql<{
+      source: string;
+      local_source: string;
+    }>`select source, local_source from iiif_resource where id = ${manifestId}`
+  );
+
+  if (!file.local_source) {
+    throw new Error('Not found');
+  }
+
+  const fileContent = fs.readFileSync(file.local_source);
+
+  const rawManifest = JSON.parse(fileContent.toString('utf-8'));
+
+  context.set('Access-Control-Allow-Origin', '*');
+
+  rawManifest.service = rawManifest.service ? rawManifest.service : [];
+  rawManifest.service.push({
+    '@context': 'http://iiif.io/api/search/0/context.json',
+    '@id': `${gatewayHost}/s/${siteSlug}/madoc/api/manifests/${manifestId}/search/1.0`,
+    profile: 'http://iiif.io/api/search/0/search',
+    label: 'Search within',
+    service: {
+      '@id': 'https://wellcomelibrary.org/annoservices/autocomplete/b18035723',
+      profile: 'http://iiif.io/api/search/0/autocomplete',
+      label: 'Get suggested words in this manifest',
+    },
+  });
+  // rawManifest.service.push({
+  //   '@context': 'http://iiif.io/api/search/0/context.json',
+  //   '@id': 'https://wellcomelibrary.org/annoservices/search/b18035723',
+  //   profile: 'http://iiif.io/api/search/0/search',
+  //   label: 'Search within this manifest',
+  //   service: {
+  //     '@id': 'https://wellcomelibrary.org/annoservices/autocomplete/b18035723',
+  //     profile: 'http://iiif.io/api/search/0/autocomplete',
+  //     label: 'Get suggested words in this manifest',
+  //   },
+  // });
+
+  context.response.body = rawManifest;
+};

--- a/services/madoc-ts/src/routes/iiif/manifests/search-manifest.ts
+++ b/services/madoc-ts/src/routes/iiif/manifests/search-manifest.ts
@@ -1,0 +1,80 @@
+import { RouteMiddleware } from '../../../types/route-middleware';
+import { sql } from 'slonik';
+import { SearchServiceSearchResponse } from '@hyperion-framework/types';
+
+const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
+
+export const searchManifest: RouteMiddleware<{ id: number }> = async context => {
+  const { siteApi } = context.state;
+
+  const manifestUrn = `urn:madoc:manifest:${context.params.id}`;
+
+  const { q, field_type, selector_type, parent_property, capture_model_id, source_id } = context.request.query;
+
+  if (!q) {
+    context.response.body = {
+      '@context': 'http://iiif.io/api/presentation/3/context.json',
+      '@id': `${gatewayHost}${context.path}`,
+      '@type': 'sc:AnnotationList',
+      resources: [],
+    };
+    return;
+  }
+
+  const response = await siteApi.searchPublishedModelFields({ manifest: manifestUrn }, q, {
+    field_type,
+    selector_type,
+    capture_model_id,
+    parent_property,
+  });
+
+  // 0. Filter out all of the empty selectors? maybe.
+  // 1. Get list of all of the canvas ids.
+  const canvasIds: string[] = [];
+
+  for (const result of response.results) {
+    if (canvasIds.indexOf(result.canvas) === -1) {
+      canvasIds.push(result.canvas);
+    }
+  }
+
+  const sources = await context.connection.any(sql<{ id: number; source: string }>`
+    select id, source from iiif_resource where 'urn:madoc:canvas:' || id = any (${sql.array(canvasIds, 'text')})
+  `);
+
+  const sourceMap: { [id: string]: string } = {};
+
+  for (const source of sources) {
+    sourceMap[`urn:madoc:canvas:${source.id}`] = source.source;
+  }
+
+  // 2. Make query to madoc db for all of the data we need about the canvas
+  // 3. Build up annotation list
+  // 4. Possible autocomplete and stemming on field type
+  // 5. Possible hits integration.
+
+  context.set('Access-Control-Allow-Origin', '*');
+
+  const searchResponse: SearchServiceSearchResponse = {
+    '@context': 'http://iiif.io/api/presentation/3/context.json',
+    '@id': `${gatewayHost}${context.path}`,
+    '@type': 'sc:AnnotationList',
+    resources: response.results.map(result => {
+      return {
+        '@id': `${gatewayHost}${context.path}/resources/${result.id}`,
+        '@type': 'oa:Annotation',
+        motivation: 'sc:painting',
+        resource: {
+          '@type': 'cnt:ContentAsText',
+          chars: result.value,
+        },
+        on: result.selector
+          ? `${sourceMap[result.canvas]}#xywh=${~~result.selector.x},${~~result.selector.y},${~~result.selector
+              .width},${~~result.selector.height}`
+          : sourceMap[result.canvas],
+      };
+    }),
+  };
+
+  context.response.body = searchResponse;
+};

--- a/services/madoc-ts/src/types/schemas/search.ts
+++ b/services/madoc-ts/src/types/schemas/search.ts
@@ -1,0 +1,13 @@
+export type ModelSearch = {
+  id: string;
+  canvas: string;
+  manifest: string | null;
+  field_type: string;
+  value: string;
+  property?: string;
+  capture_model_id: string;
+  parent_property: string;
+  selector?: any;
+  selector_type?: string;
+  context: string[];
+};


### PR DESCRIPTION
First implementation with limitations:
- Search across whole site, not per project
- Search is limited to test fields with box selectors
- Will only search approved items
- Output manifests do not support changes made after import - will patch the original manifest
