### PR TITLE
MAD-428 Plaintext OCR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       - ./services/tasks-api/schemas:/home/node/app/schemas
 
   model-api:
-    image: digirati/capture-models:v0.11.0
+    image: digirati/capture-models:v0.11.1
     environment:
       - SERVER_PORT=3000
       - DATABASE_HOST=shared-postgres

--- a/services/madoc-ts/package.json
+++ b/services/madoc-ts/package.json
@@ -35,9 +35,9 @@
   "dependencies": {
     "@atlas-viewer/atlas": "^1.2.0",
     "@atlas-viewer/iiif-image-api": "^1.2.0",
-    "@capture-models/editor": "^0.11.0",
-    "@capture-models/helpers": "^0.11.0",
-    "@capture-models/types": "^0.11.0",
+    "@capture-models/editor": "^0.11.1",
+    "@capture-models/helpers": "^0.11.1",
+    "@capture-models/types": "^0.11.1",
     "@hyperion-framework/react-vault": "1.0.0-alpha.23",
     "@hyperion-framework/types": "1.0.0-alpha.14",
     "@hyperion-framework/vault": "1.0.0-alpha.23",

--- a/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/DynamicDataSources.extension.ts
+++ b/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/DynamicDataSources.extension.ts
@@ -1,0 +1,74 @@
+import { traverseDocument } from '@capture-models/helpers';
+import { BaseField, CaptureModel } from '@capture-models/types';
+import { ApiClient } from '../../../gateway/api';
+import { CaptureModelExtension } from '../extension';
+import { DynamicData } from './types';
+
+export class DynamicDataSourcesExtension implements CaptureModelExtension {
+  api: ApiClient;
+  dataLoaders: DynamicData[];
+  constructor(api: ApiClient, dataLoaders: DynamicData[]) {
+    this.api = api;
+    this.dataLoaders = dataLoaders;
+  }
+
+  async onCloneCaptureModel(captureModel: CaptureModel): Promise<CaptureModel> {
+    if (this.dataLoaders.length === 0) {
+      return captureModel;
+    }
+
+    const dataLoaderTypes = this.dataLoaders.map(loader => loader.definition.id);
+
+    const state = {
+      fields: [] as Array<{ field: BaseField; key: string; source: string }>,
+    };
+
+    // 1. Does the capture model support data sources.
+    traverseDocument(captureModel.document, {
+      visitField(field, key) {
+        const dataSources = field.dataSources
+          ? field.dataSources.filter(source => dataLoaderTypes.indexOf(source) !== -1)
+          : undefined;
+
+        // 2. Do any of the fields have data sources?
+        if (dataSources) {
+          for (const source of dataSources) {
+            state.fields.push({
+              field,
+              key,
+              source,
+            });
+          }
+        }
+      },
+    });
+
+    if (state.fields.length === 0 || !captureModel.id) {
+      return captureModel;
+    }
+
+    // 3. Resolve data needed about the resource
+    const { canvas } = this.api.parseModelTarget(captureModel.target);
+
+    if (!canvas) {
+      // No valid target.
+      return captureModel;
+    }
+
+    // 4. Call each of the extensions to get the data from the source
+    for (const field of state.fields) {
+      const loader = this.dataLoaders.find(candidateLoader => candidateLoader.definition.id === field.source);
+      // Just double check.
+      if (loader) {
+        try {
+          // 5. Modify and return the model.
+          await loader.loader(field.field, field.key, canvas, this.api);
+        } catch (err) {
+          console.log('Loader error', err);
+        }
+      }
+    }
+
+    return await this.api.updateCaptureModel(captureModel.id, captureModel);
+  }
+}

--- a/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/README.md
+++ b/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/README.md
@@ -1,0 +1,22 @@
+# Dynamic data sources
+This extension allows dynamic data sources to be defined and loaded when a capture model is created.
+
+## Function of the extension
+When a capture model is cloned, the following will happen:
+- Detect if any of the fields in the capture model have data sources defined
+- Load related code for generating data source, passing in the current resource and API
+- Request the new value from the dynamic data source
+- Return the model
+
+### Persisting data on publish
+This might not be in the scope of this but when data is saved (revision approved) then this extension
+could detect and persist the linked properties back to the source. This is not current planned.
+
+
+### Possible uses
+In madoc there is a lot of sources of data that could be cycled like this in a project.
+
+- Plain text transcriptions
+- Canvas labels
+- Metadata pairs
+- Tags or JSON-LD documents that can be associated

--- a/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/sources/Plaintext.source.ts
+++ b/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/sources/Plaintext.source.ts
@@ -1,0 +1,53 @@
+import { FieldSource } from '@capture-models/editor';
+import { DynamicData, DynamicDataLoader } from '../types';
+
+const plaintextSourceDefinition: FieldSource = {
+  id: 'plaintext-source',
+  name: 'Plaintext',
+  description: 'Source plain-text from seeAlso fields in IIIF resources.',
+  defaultProps: {},
+  fieldTypes: ['text-field', 'html-field', 'tagged-text-field'],
+};
+
+const plainTextSourceLoader: DynamicDataLoader = async (field, key, canvas, api) => {
+  try {
+    // 1. Load canvas seeAlso
+    const linking = await api.getCanvasLinking(canvas.id);
+
+    const matchingPlaintext = linking.linking.find(singleLink => {
+      // @todo this could be extended to be configured from the field.
+      return singleLink.property === 'seeAlso' && singleLink.link.format === 'text/plain';
+    });
+
+    if (!matchingPlaintext) {
+      return field;
+    }
+
+    // 2. Look for suitable plain text and load it
+    const plaintextUrl = matchingPlaintext.file ? api.resolveUrl(matchingPlaintext.link.id) : matchingPlaintext.link.id;
+    const plaintext = await fetch(plaintextUrl).then(t => t.text());
+
+    if (!plaintext) {
+      return field;
+    }
+
+    // 3. Add plain text to value of field.
+    if (field.type === 'html-field') {
+      // @todo maybe make this configurable.
+      field.value = plaintext.split('\n').join('<br />');
+    } else {
+      // 3. Add plain text to value of field.
+      field.value = plaintext;
+    }
+
+    return field;
+  } catch (err) {
+    console.log(err);
+    return field;
+  }
+};
+
+export const plainTextSource: DynamicData = {
+  loader: plainTextSourceLoader,
+  definition: plaintextSourceDefinition,
+};

--- a/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/types.ts
+++ b/services/madoc-ts/src/extensions/capture-models/DynamicDataSources/types.ts
@@ -1,0 +1,15 @@
+import { FieldSource } from '@capture-models/editor';
+import { BaseField } from '@capture-models/types';
+import { ApiClient } from '../../../gateway/api';
+
+export type DynamicDataLoader = (
+  field: BaseField,
+  key: string,
+  resource: { type: string; id: number },
+  api: ApiClient
+) => Promise<BaseField>;
+
+export type DynamicData = {
+  definition: FieldSource;
+  loader: (field: BaseField, key: string, resource: { type: string; id: number }, api: ApiClient) => Promise<BaseField>;
+};

--- a/services/madoc-ts/src/extensions/capture-models/Paragraphs/Paragraphs.extension.ts
+++ b/services/madoc-ts/src/extensions/capture-models/Paragraphs/Paragraphs.extension.ts
@@ -70,8 +70,6 @@ export class Paragraphs implements CaptureModelExtension {
       ? await this.api.getStorageJsonData(matchingCaptureModel.file.bucket, matchingCaptureModel.file.path)
       : await fetch(matchingCaptureModel.link.id).then(r => r.json());
 
-    console.log({ data });
-
     //   4.2 - Make wrapper document and traverse the fields, minting new IDs
     const documentWrapper = preprocessCaptureModel(data);
 
@@ -101,7 +99,6 @@ export class Paragraphs implements CaptureModelExtension {
     });
 
     try {
-      console.log('UPDATING CAPTURE MODEL');
       // 6. Save the model and return it.
       return await this.api.updateCaptureModel(captureModel.id, captureModel);
       ///  6.1 - Any errors - add to the placeholder field in the future

--- a/services/madoc-ts/src/frontend/admin/molecules/CollapsibleTaskList.tsx
+++ b/services/madoc-ts/src/frontend/admin/molecules/CollapsibleTaskList.tsx
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { BaseTask } from '../../../gateway/tasks/base-task';
+import { SmallButton } from '../../shared/atoms/Button';
+import { Status } from '../../shared/atoms/Status';
+import { TableActions, TableContainer, TableRow, TableRowLabel } from '../../shared/atoms/Table';
+
+export const CollapsibleTaskList: React.FC<{
+  tasks: BaseTask[];
+  trigger: (id: string) => void;
+  taskStatusMap: any;
+  tasksToShow?: number;
+}> = ({ tasks, taskStatusMap, trigger, tasksToShow = 10 }) => {
+  const { t } = useTranslation();
+  const canOpen = tasks.length > tasksToShow;
+  const [isOpen, setIsOpen] = useState(!canOpen);
+
+  return (
+    <TableContainer>
+      {(isOpen ? tasks : tasks.slice(0, tasksToShow)).map((subtask: BaseTask) => (
+        <TableRow key={subtask.id}>
+          <TableRowLabel>
+            <Status status={subtask.status || 0} text={t(subtask.status_text || 'unknown')} />
+          </TableRowLabel>
+          <TableRowLabel>
+            <Link to={`/tasks/${subtask.id}`}>{subtask.name}</Link>
+          </TableRowLabel>
+          <TableActions>
+            <SmallButton
+              onClick={() => (subtask.id ? trigger(subtask.id) : null)}
+              disabled={subtask.id ? taskStatusMap[subtask.id] : false}
+            >
+              {t('Retry')}
+            </SmallButton>
+          </TableActions>
+        </TableRow>
+      ))}
+      {isOpen ? null : (
+        <TableRow>
+          <TableRowLabel>
+            <em>Showing {tasksToShow} of {tasks.length}</em>
+          </TableRowLabel>
+          <TableRowLabel>
+            <SmallButton onClick={() => setIsOpen(true)}>show all</SmallButton>
+          </TableRowLabel>
+        </TableRow>
+      )}
+    </TableContainer>
+  );
+};

--- a/services/madoc-ts/src/frontend/admin/molecules/SortedTaskList.tsx
+++ b/services/madoc-ts/src/frontend/admin/molecules/SortedTaskList.tsx
@@ -7,6 +7,7 @@ import { SmallButton } from '../../shared/atoms/Button';
 import { Status } from '../../shared/atoms/Status';
 import { TableActions, TableContainer, TableRow, TableRowLabel } from '../../shared/atoms/Table';
 import { taskTypeToLabel } from '../../shared/utility/task-type-to-label';
+import { CollapsibleTaskList } from './CollapsibleTaskList';
 
 export const SortedTaskList: React.FC<{ tasks: BaseTask[]; trigger: (id: string) => void; taskStatusMap: any }> = ({
   tasks,
@@ -44,26 +45,7 @@ export const SortedTaskList: React.FC<{ tasks: BaseTask[]; trigger: (id: string)
         return (
           <div key={sortedType}>
             <h4>{t(taskTypeToLabel(sortedType))}</h4>
-            <TableContainer>
-              {sortedSubtasks[sortedType].map((subtask: BaseTask) => (
-                <TableRow key={subtask.id}>
-                  <TableRowLabel>
-                    <Status status={subtask.status || 0} text={t(subtask.status_text || 'unknown')} />
-                  </TableRowLabel>
-                  <TableRowLabel>
-                    <Link to={`/tasks/${subtask.id}`}>{subtask.name}</Link>
-                  </TableRowLabel>
-                  <TableActions>
-                    <SmallButton
-                      onClick={() => (subtask.id ? trigger(subtask.id) : null)}
-                      disabled={subtask.id ? taskStatusMap[subtask.id] : false}
-                    >
-                      Retry
-                    </SmallButton>
-                  </TableActions>
-                </TableRow>
-              ))}
-            </TableContainer>
+            <CollapsibleTaskList tasks={sortedSubtasks[sortedType]} trigger={trigger} taskStatusMap={taskStatusMap} />
           </div>
         );
       })}

--- a/services/madoc-ts/src/frontend/admin/pages/content/canvases/edit-canvas-linking.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/content/canvases/edit-canvas-linking.tsx
@@ -17,7 +17,7 @@ type EditCanvasLinking = {
 
 export const EditCanvasLinking: UniversalComponent<EditCanvasLinking> = createUniversalComponent<EditCanvasLinking>(
   () => {
-    const { id, manifestId } = useParams();
+    const { id, manifestId } = useParams<{ id: string; manifestId: string }>();
     const { data, refetch } = useData(EditCanvasLinking);
 
     return (

--- a/services/madoc-ts/src/frontend/admin/pages/content/manifests/manifest.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/content/manifests/manifest.tsx
@@ -43,6 +43,7 @@ export const ManifestView: UniversalComponent<ManifestViewType> = createUniversa
             { label: t('edit structure'), link: `/manifests/${id}/structure` },
             { label: t('edit linking'), link: `/manifests/${id}/linking` },
             { label: t('projects'), link: `/manifests/${id}/projects` },
+            { label: t('ocr'), link: `/manifests/${id}/ocr` },
             { label: t('delete'), link: `/manifests/${id}/delete` },
             { label: t('search index'), link: `/manifests/${id}/search` },
           ]}

--- a/services/madoc-ts/src/frontend/admin/pages/crowdsourcing/model-editor/full-document-editor.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/crowdsourcing/model-editor/full-document-editor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   DocumentEditor,
   DocumentStore,
@@ -23,6 +23,9 @@ export const FullDocumentEditor: React.FC = () => {
   }));
   const actions = DocumentStore.useStoreActions(a => a);
   const removeStructureField = StructureStore.useStoreActions(a => a.removeField);
+  const sourceTypes = useMemo(() => {
+    return api.getCaptureModelDataSources().map(source => source.definition);
+  }, [api]);
 
   return (
     <div style={{ display: 'flex', fontSize: 14 }}>
@@ -49,6 +52,7 @@ export const FullDocumentEditor: React.FC = () => {
         {state.selectedField ? (
           <div>
             <FieldEditor
+              sourceTypes={sourceTypes}
               key={state.selectedField}
               term={state.selectedField}
               field={state.subtree.properties[state.selectedField][0] as BaseField}

--- a/services/madoc-ts/src/frontend/admin/pages/crowdsourcing/projects/project-content.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/crowdsourcing/projects/project-content.tsx
@@ -1,4 +1,3 @@
-import { Button, ButtonRow } from '../../../../shared/atoms/Button';
 import { UniversalComponent } from '../../../../types';
 import React from 'react';
 import { useApi } from '../../../../shared/hooks/use-api';
@@ -49,7 +48,7 @@ export const ProjectContent: UniversalComponent<ProjectContentType> = createUniv
           </HelpText>
           <CollectionEditorStructure
             searchCollections={true}
-            searchManifests={false}
+            searchManifests={true}
             enableNavigation={true}
             hideManifests={false}
             items={data ? data.items : undefined}

--- a/services/madoc-ts/src/frontend/admin/pages/enrichment/ocr.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/enrichment/ocr.tsx
@@ -1,97 +1,20 @@
-import { ManifestLinking } from '@hyperion-framework/types';
 import React from 'react';
-import { ManifestListResponse } from '../../../../types/schemas/manifest-list';
-import { Heading1 } from '../../../shared/atoms/Heading1';
-import { Heading3 } from '../../../shared/atoms/Heading3';
-import { TableContainer, TableRow, TableRowLabel } from '../../../shared/atoms/Table';
 import { WidePage } from '../../../shared/atoms/WidePage';
-import { LocaleString } from '../../../shared/components/LocaleString';
-import { HrefLink } from '../../../shared/utility/href-link';
-import { UniversalComponent } from '../../../types';
-import { useData } from '../../../shared/hooks/use-data';
-import { createUniversalComponent } from '../../../shared/utility/create-universal-component';
+import { renderUniversalRoutes } from '../../../shared/utility/server-utils';
+import { UniversalRoute } from '../../../types';
 import { AdminHeader } from '../../molecules/AdminHeader';
-import { Pagination } from '../../molecules/Pagination';
 
-type OcrPageType = {
-  data: {
-    hocr: ManifestListResponse;
-    alto: ManifestListResponse;
-  };
-  query: {};
-  params: { page: string };
-  variables: { page: number };
-  context: {};
+export const OcrPage: React.FC<{ route: UniversalRoute }> = ({ route }) => {
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: 'Site admin', link: '/' },
+          { label: 'OCR', active: true, link: `/enrichment/ocr` },
+        ]}
+        title="OCR Processing"
+      />
+      <WidePage>{renderUniversalRoutes(route.routes)}</WidePage>
+    </>
+  );
 };
-
-export const OcrPage: UniversalComponent<OcrPageType> = createUniversalComponent<OcrPageType>(
-  () => {
-    const { data, status } = useData(OcrPage);
-
-    const { alto, hocr } = data || {};
-
-    return (
-      <>
-        <AdminHeader
-          breadcrumbs={[
-            { label: 'Site admin', link: '/' },
-            { label: 'OCR', active: true, link: `/enrichment/ocr` },
-          ]}
-          title="Manifests with supported OCR"
-        />
-        <WidePage>
-          <h3>Alto XML OCR</h3>
-          <TableContainer>
-            {alto?.manifests.map(manifest => (
-              <TableRow>
-                <TableRowLabel>
-                  <HrefLink href={`/enrichment/ocr/manifest/${manifest.id}`}>
-                    <LocaleString>{manifest.label}</LocaleString>
-                  </HrefLink>
-                </TableRowLabel>
-              </TableRow>
-            ))}
-          </TableContainer>
-          <Pagination
-            page={alto ? alto.pagination.page : 1}
-            totalPages={alto ? alto.pagination.totalPages : 1}
-            stale={!alto}
-          />
-
-          <h3>hOCR</h3>
-          <TableContainer>
-            {hocr?.manifests.map(manifest => (
-              <TableRow>
-                <TableRowLabel>
-                  <HrefLink href={`/enrichment/ocr/manifest/${manifest.id}`}>
-                    <LocaleString>{manifest.label}</LocaleString>
-                  </HrefLink>
-                </TableRowLabel>
-              </TableRow>
-            ))}
-          </TableContainer>
-          <Pagination
-            page={hocr ? hocr.pagination.page : 1}
-            totalPages={hocr ? hocr.pagination.totalPages : 1}
-            stale={!hocr}
-          />
-        </WidePage>
-      </>
-    );
-  },
-  {
-    getKey(params) {
-      return ['manifests-ocr-filter', { page: params.page ? Number(params.page) : 0 }];
-    },
-    async getData(key, vars, api) {
-      const [alto, hocr] = await Promise.all([
-        api.getManifests(vars.page, { filter: 'ocr_alto' }),
-        api.getManifests(vars.page, { filter: 'ocr_hocr' }),
-      ]);
-      return {
-        alto,
-        hocr,
-      };
-    },
-  }
-);

--- a/services/madoc-ts/src/frontend/admin/pages/enrichment/ocr/ocr-list.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/enrichment/ocr/ocr-list.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { ManifestListResponse } from '../../../../../types/schemas/manifest-list';
+import { TableContainer, TableRow, TableRowLabel } from '../../../../shared/atoms/Table';
+import { LocaleString } from '../../../../shared/components/LocaleString';
+import { Pagination } from '../../../../shared/components/Pagination';
+import { useData } from '../../../../shared/hooks/use-data';
+import { createUniversalComponent } from '../../../../shared/utility/create-universal-component';
+import { HrefLink } from '../../../../shared/utility/href-link';
+import { UniversalComponent } from '../../../../types';
+
+type OcrListPageType = {
+  data: {
+    hocr: ManifestListResponse;
+    alto: ManifestListResponse;
+  };
+  query: {};
+  params: { page: string };
+  variables: { page: number };
+  context: {};
+};
+
+export const OcrListPage: UniversalComponent<OcrListPageType> = createUniversalComponent<OcrListPageType>(
+  () => {
+    const { data } = useData(OcrListPage);
+
+    const { alto, hocr } = data || {};
+
+    return (
+      <>
+        <h3>Alto XML OCR</h3>
+        <TableContainer>
+          {alto?.manifests.map(manifest => (
+            <TableRow>
+              <TableRowLabel>
+                <HrefLink href={`/manifests/${manifest.id}/ocr`}>
+                  <LocaleString>{manifest.label}</LocaleString>
+                </HrefLink>
+              </TableRowLabel>
+            </TableRow>
+          ))}
+        </TableContainer>
+        <Pagination
+          page={alto ? alto.pagination.page : 1}
+          totalPages={alto ? alto.pagination.totalPages : 1}
+          stale={!alto}
+        />
+
+        {hocr && hocr.manifests.length ? (
+          <>
+            <h3>hOCR</h3>
+            <TableContainer>
+              {hocr?.manifests.map(manifest => (
+                <TableRow>
+                  <TableRowLabel>
+                    <HrefLink href={`/manifests/${manifest.id}/ocr`}>
+                      <LocaleString>{manifest.label}</LocaleString>
+                    </HrefLink>
+                  </TableRowLabel>
+                </TableRow>
+              ))}
+            </TableContainer>
+            <Pagination
+              page={hocr ? hocr.pagination.page : 1}
+              totalPages={hocr ? hocr.pagination.totalPages : 1}
+              stale={!hocr}
+            />
+          </>
+        ) : null}
+      </>
+    );
+  },
+  {
+    getKey(params) {
+      return ['manifests-ocr-filter', { page: params.page ? Number(params.page) : 0 }];
+    },
+    async getData(key, vars, api) {
+      const [alto, hocr] = await Promise.all([
+        api.getManifests(vars.page, { filter: 'ocr_alto' }),
+        api.getManifests(vars.page, { filter: 'ocr_hocr' }),
+      ]);
+      return {
+        alto,
+        hocr,
+      };
+    },
+  }
+);

--- a/services/madoc-ts/src/frontend/admin/pages/tasks/generic-task.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/tasks/generic-task.tsx
@@ -2,6 +2,7 @@ import ReactTimeago from 'react-timeago';
 import { BaseTask } from '../../../../gateway/tasks/base-task';
 import React, { useState } from 'react';
 import { useMutation } from 'react-query';
+import { ErrorMessage } from '../../../shared/atoms/ErrorMessage';
 import { useApi } from '../../../shared/hooks/use-api';
 import { SortedTaskList } from '../../molecules/SortedTaskList';
 
@@ -27,6 +28,11 @@ export const GenericTask: React.FC<{ task: BaseTask; statusBar?: JSX.Element; sn
   return (
     <div>
       <h1>{task.name}</h1>
+      {task.state.error ? (
+        <ErrorMessage>
+          <pre>{task.state.error}</pre>
+        </ErrorMessage>
+      ) : null}
       {snippet}
       {task.description ? <p>{task.description}</p> : null}
       <p>{task.created_at ? <ReactTimeago date={task.created_at} /> : null}</p>

--- a/services/madoc-ts/src/frontend/admin/routes.tsx
+++ b/services/madoc-ts/src/frontend/admin/routes.tsx
@@ -3,6 +3,7 @@ import { CanvasSearchIndex } from './pages/content/canvases/canvas-search-index'
 import { CollectionView } from './pages/content/collections/collection';
 import { ViewCanvasLinking } from './pages/content/linking/view-linking';
 import { SiteConfiguration } from './pages/content/site-configuration';
+import { OcrListPage } from './pages/enrichment/ocr/ocr-list';
 import { ExportSite } from './pages/export/export-site';
 import { Homepage } from './pages/homepage';
 import { CollectionList } from './pages/content/collections/collection-list';
@@ -162,6 +163,11 @@ export const routes: UniversalRoute[] = [
         exact: true,
         component: ManifestSearchIndex,
       },
+      {
+        path: '/manifests/:id/ocr',
+        exact: true,
+        component: OcrManifest,
+      },
     ],
   },
   {
@@ -318,14 +324,21 @@ export const routes: UniversalRoute[] = [
   },
   {
     path: '/enrichment/ocr',
-    exact: true,
     component: OcrPage,
+    routes: [
+      {
+        path: '/enrichment/ocr',
+        exact: true,
+        component: OcrListPage,
+      },
+      {
+        path: '/enrichment/ocr/manifest/:id',
+        exact: true,
+        component: OcrManifest,
+      },
+    ],
   },
-  {
-    path: '/enrichment/ocr/manifest/:id',
-    exact: true,
-    component: OcrManifest,
-  },
+
   // Export
   {
     path: '/export/site',

--- a/services/madoc-ts/src/frontend/shared/atoms/Breadcrumbs.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/Breadcrumbs.tsx
@@ -22,6 +22,11 @@ export const BreadcrumbItem = styled.div<{ active?: boolean; color?: string; $ac
   a {
     text-decoration: none;
     color: ${props => (props.color ? props.color : `rgba(255, 255, 255, 0.7)`)};
+    max-width: 200px;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
     &:hover {
       color: ${props => (props.color ? 'black' : `rgba(255, 255, 255, 1)`)};
     }
@@ -75,7 +80,7 @@ export const Breadcrumbs: React.FC<{
           <React.Fragment key={item.link}>
             {n !== 0 ? <BreadcrumbSeparator color={color}>{`/`}</BreadcrumbSeparator> : null}
             <BreadcrumbItem key={item.link} active={item.active} color={color} $activeColor={$activeColor}>
-              <Link to={item.link}>{item.label}</Link>
+              <Link to={item.link} title={item.label}>{item.label}</Link>
             </BreadcrumbItem>
           </React.Fragment>
         );

--- a/services/madoc-ts/src/gateway/api.ts
+++ b/services/madoc-ts/src/gateway/api.ts
@@ -45,7 +45,7 @@ import {
 } from './tasks/crowdsourcing-review';
 import { CrowdsourcingCanvasTask } from './tasks/crowdsourcing-canvas-task';
 import { ConfigResponse } from '../types/schemas/config-response';
-import { ResourceLinkResponse } from '../database/queries/linking-queries';
+import { ResourceLinkResponse, ResourceLinkRow } from '../database/queries/linking-queries';
 
 export class ApiClient {
   private readonly gateway: string;
@@ -150,6 +150,7 @@ export class ApiClient {
       jwt = this.jwt,
       publicRequest = false,
       xml = false,
+      plaintext = false,
       returnText = false,
       headers = {},
       raw = false,
@@ -159,6 +160,7 @@ export class ApiClient {
       jwt?: string;
       publicRequest?: boolean;
       xml?: boolean;
+      plaintext?: boolean;
       returnText?: boolean;
       headers?: any;
       raw?: boolean;
@@ -176,6 +178,7 @@ export class ApiClient {
       jwt: jwt,
       asUser: this.user,
       xml,
+      plaintext,
       returnText,
       headers,
       raw,
@@ -1108,8 +1111,29 @@ export class ApiClient {
     );
   }
 
+  async saveStoragePlainText(bucket: string, fileName: string, text: string, isPublic = false) {
+    return this.request<{
+      success: boolean;
+      stats: {
+        modified: string;
+        size: number;
+      };
+    }>(
+      isPublic
+        ? `/api/storage/data/${bucket}/public/${fileName.endsWith('.txt') ? fileName : `${fileName}.txt`}`
+        : `/api/storage/data/${bucket}/${fileName.endsWith('.txt') ? fileName : `${fileName}.txt`}`,
+      {
+        method: 'POST',
+        body: text,
+        plaintext: true,
+      }
+    );
+  }
+
   async convertLinkingProperty(id: number) {
-    return this.request<any>(`/api/madoc/iiif/linking/${id}/convert`, {
+    return this.request<{
+      link: ResourceLinkRow;
+    }>(`/api/madoc/iiif/linking/${id}/convert`, {
       method: 'POST',
     });
   }

--- a/services/madoc-ts/src/gateway/fetch-json.ts
+++ b/services/madoc-ts/src/gateway/fetch-json.ts
@@ -9,6 +9,7 @@ export async function fetchJson<Return>(
     jwt,
     asUser,
     xml,
+    plaintext,
     returnText,
     headers: additionalHeaders = {},
     raw,
@@ -18,6 +19,7 @@ export async function fetchJson<Return>(
     jwt?: string;
     asUser?: { userId?: number; siteId?: number };
     xml?: boolean;
+    plaintext?: boolean;
     returnText?: boolean;
     headers?: any;
     raw?: boolean;
@@ -35,7 +37,9 @@ export async function fetchJson<Return>(
     headers.Authorization = `Bearer ${jwt}`;
   }
 
-  if (xml && body) {
+  if (plaintext && body) {
+    headers['Content-Type'] = 'text/plain';
+  } else if (xml && body) {
     headers['Content-Type'] = 'text/xml';
   } else if (body) {
     headers['Content-Type'] = 'application/json';
@@ -53,7 +57,7 @@ export async function fetchJson<Return>(
   const resp = await fetch(`${apiGateway}${endpoint}`, {
     headers,
     method,
-    body: body ? (xml ? body : JSON.stringify(body)) : undefined,
+    body: body ? (xml || plaintext ? body : JSON.stringify(body)) : undefined,
     credentials: 'omit',
   });
 

--- a/services/madoc-ts/src/gateway/tasks/process-canvas-ocr.ts
+++ b/services/madoc-ts/src/gateway/tasks/process-canvas-ocr.ts
@@ -198,7 +198,17 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
         }
       } catch (err) {
         console.log(err);
-        await api.updateTask(task.id, { status: -1, status_text: `Could not load external OCR` });
+        await api.updateTask(task.id, {
+          status: -1,
+          status_text: `Could not load external OCR`,
+          state: { error: `${err}` },
+        });
+        if (task.parent_task) {
+          await api.updateTask(task.parent_task, {
+            status: -1,
+            status_text: `Could not load some OCR materials`,
+          });
+        }
         return;
       }
 

--- a/services/madoc-ts/src/gateway/tasks/process-canvas-ocr.ts
+++ b/services/madoc-ts/src/gateway/tasks/process-canvas-ocr.ts
@@ -18,10 +18,11 @@ export const status = [
 
 export interface ProcessManifestOcr extends BaseTask {
   type: 'canvas-ocr-manifest';
-  parameters: [number, number, number, string, 'alto' | 'hocr'];
+  parameters: [number, number, number, string, 'alto' | 'hocr' | 'plain-text'];
   status: -1 | 0 | 1 | 2 | 3;
   state: {
     link_id?: number;
+    error?: string;
   };
 }
 
@@ -31,7 +32,7 @@ export function createTask(
   siteId: number,
   userId: number,
   link: string,
-  ocrType: 'alto' | 'hocr'
+  ocrType: 'alto' | 'hocr' | 'plain-text'
 ): ProcessManifestOcr {
   return {
     type: 'canvas-ocr-manifest',
@@ -190,6 +191,27 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
 
             // Queue for re-index after adding the OCR.
             await api.indexCanvas(canvasId);
+
+            break;
+          }
+          case 'plain-text': {
+            // Is it an ID.
+            const linkId = Number(link);
+
+            if (!linkId || Number.isNaN(linkId)) {
+              throw new Error('OCR link is not a valid identifier for plain text resource');
+            }
+
+            // Load the text.
+            const addedLink = await userApi.convertLinkingProperty(linkId);
+
+            await api.updateTask(task.id, {
+              status: 3,
+              status_text: 'Imported',
+              state: {
+                link_id: addedLink.link.id,
+              },
+            });
 
             break;
           }

--- a/services/madoc-ts/src/gateway/tasks/process-manifest-ocr.ts
+++ b/services/madoc-ts/src/gateway/tasks/process-manifest-ocr.ts
@@ -61,6 +61,8 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
         if (spendIds.indexOf(link.resource_id) !== -1) {
           continue;
         }
+
+        // META+ALTO detection.
         if (
           (link.link.format === 'text/xml' || link.link.format === 'application/xml+alto') &&
           link.link.profile &&
@@ -79,8 +81,10 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
               'alto'
             )
           );
+          continue;
         }
 
+        // hOCR detection
         if (
           link.link.format === 'text/vnd.hocr+html' &&
           link.link.profile &&
@@ -101,6 +105,26 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
               'hocr'
             )
           );
+          continue;
+        }
+
+        // Plain text detection
+        if (link.link.format === 'text/plain') {
+          // Be sure not to add it twice.
+          spendIds.push(link.resource_id);
+          // Create task if the linked file is not already stored.
+          if (!link.file) {
+            subTasks.push(
+              processCanvasOcr.createTask(
+                link.resource_id,
+                `Plain text import for Canvas ID: ${link.resource_id}`,
+                siteId,
+                userId,
+                `${link.id}`, // We pass the identifier here instead of the link
+                'plain-text'
+              )
+            );
+          }
         }
       }
 

--- a/services/madoc-ts/src/gateway/tasks/process-manifest-ocr.ts
+++ b/services/madoc-ts/src/gateway/tasks/process-manifest-ocr.ts
@@ -45,7 +45,7 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
   switch (name) {
     case 'created': {
       // The task at hand.
-      const task = await api.getTask<ProcessManifestOcr>(taskId);
+      const task = await api.acceptTask<ProcessManifestOcr>(taskId);
 
       const [manifestId, siteId, userId] = task.parameters;
       const userApi = api.asUser({ siteId, userId });
@@ -140,7 +140,7 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
 
       break;
     }
-    case `subtask_type_status.madoc-ocr-canvas.${tasks.STATUS.DONE}`: {
+    case `subtask_type_status.canvas-ocr-manifest.${tasks.STATUS.DONE}`: {
       // When they're all done, mark this task as done - I think that's all?
       await api.updateTask(taskId, {
         status: 3,

--- a/services/madoc-ts/src/routes/iiif/linking/convert-linking.ts
+++ b/services/madoc-ts/src/routes/iiif/linking/convert-linking.ts
@@ -68,6 +68,27 @@ export const convertLinking: RouteMiddleware<{ id: string }> = async context => 
   const mediaType = contentType.parse(mediaTypeHeader);
 
   switch (mediaType.type) {
+    // Plain text
+    case 'text/plain': {
+      // Grab XML
+      const text = await externalResourceResponse.text();
+      // Save XML.
+      await userApi.saveStoragePlainText(
+        'saved-linking',
+        `${link.resource_id}/${linkHash(link.uri)}.txt`,
+        text || ' ',
+        true
+      );
+      // Update link.
+      const newFetchedLink = await updateConvertedLink('saved-linking', 'txt');
+
+      context.response.body = {
+        link: newFetchedLink,
+      };
+      return;
+    }
+
+    // Various XML formats
     case 'text/xml':
     case 'application/xml+alto':
     case 'application/xml': {
@@ -83,6 +104,8 @@ export const convertLinking: RouteMiddleware<{ id: string }> = async context => 
       };
       return;
     }
+
+    // Various JSON formats.
     case 'application/json':
     case 'text/json':
     case 'application/ld+json': {

--- a/services/madoc-ts/yarn.lock
+++ b/services/madoc-ts/yarn.lock
@@ -2250,15 +2250,15 @@
     screenfull "^3.3.2"
     whatwg-fetch "^3.0.0"
 
-"@capture-models/editor@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@capture-models/editor/-/editor-0.11.0.tgz#b452d30fabf261b6f495178cd00d9728dd27c767"
-  integrity sha512-2Fxl186wpQ33aek+EPvUCxCcpUfp9CcnjT7B3vVVAuaUZEQm3lfX84tXVQjpD2iLC6s8xHbbhSg6RORWcnfEDg==
+"@capture-models/editor@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@capture-models/editor/-/editor-0.11.1.tgz#45262acf39bdf159c187367d42b439c292a0bd7a"
+  integrity sha512-5Qe+lJnOwBu3UVFL833OZjzSlbJnX8MDnc02bowKEVNdb6x8MIcMdBTNV0zFeJ6tQxHS8rAXDpsNXEVwCloHQA==
   dependencies:
     "@atlas-viewer/atlas" "^1.1.0"
-    "@capture-models/helpers" "^0.11.0"
-    "@capture-models/plugin-api" "^0.11.0"
-    "@capture-models/types" "^0.11.0"
+    "@capture-models/helpers" "^0.11.1"
+    "@capture-models/plugin-api" "^0.11.1"
+    "@capture-models/types" "^0.11.1"
     "@hyperion-framework/react-vault" "^1.0.0-alpha.15"
     "@hyperion-framework/types" "^1.0.0-alpha.14"
     "@iiif/vocabulary" "1.0.18"
@@ -2294,30 +2294,30 @@
     use-async-effect "^2.2.1"
     use-debounce "^3.3.0"
 
-"@capture-models/helpers@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@capture-models/helpers/-/helpers-0.11.0.tgz#1250f2a7678cdd417d3713597cdf476d34dd9d0f"
-  integrity sha512-RrqAgS8E5l3CtsmHk0upKzJzDWBBjafxGFsN3Df4mQcVtJs2Wgqul0iEnRMOnMKEBu22R/KarblahMLdsynfVw==
+"@capture-models/helpers@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@capture-models/helpers/-/helpers-0.11.1.tgz#cf6f7eafa693d4ae8845d3b87e2adee44f66ddf1"
+  integrity sha512-ovLJwHuDcIY0YRdy9g68AxbgUzua+zpAXEoDeLA1FL49mRgP1t91R+1uthLn1ORGKixeCFJ62fRYq2fDA9UksQ==
   dependencies:
-    "@capture-models/plugin-api" "^0.11.0"
-    "@capture-models/types" "^0.11.0"
+    "@capture-models/plugin-api" "^0.11.1"
+    "@capture-models/types" "^0.11.1"
     fast-copy "^2.0.4"
     immer "^7.0.7"
     react "^16.13.1"
     uuid "^3.4.0"
 
-"@capture-models/plugin-api@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@capture-models/plugin-api/-/plugin-api-0.11.0.tgz#b2da52280b0a1faa4cdce004094baff47f9d320a"
-  integrity sha512-4+Z1aFAPa0bh6KMoU2k4ilWBA1b/zrDB81LjV+NR8Hwt7DpwLFzgVH96lU2/mV2ifrrtjr2EQGRkt9t4wy/flA==
+"@capture-models/plugin-api@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@capture-models/plugin-api/-/plugin-api-0.11.1.tgz#047877eff33bdcc852132d211e6d1e43082c8138"
+  integrity sha512-KAnB7dXH8vfJM0BU7+oQ9CYB2xWvOE3/o5KA37tWMBnCxJxCaFY2Sh0SuIMXZs0rM26whue8h0NMLoAIFRrfvA==
   dependencies:
-    "@capture-models/types" "^0.11.0"
+    "@capture-models/types" "^0.11.1"
     react "^16.13.1"
 
-"@capture-models/types@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@capture-models/types/-/types-0.11.0.tgz#303c687adedcfad6d099f01e4094b94366d859c9"
-  integrity sha512-PIivR8ywAaPd8DEpP/+s0fGw6uQcWSx9612PS8w7bwxVrBu/qXbDgQB67FFnTFydQbunNkXPAdvQmfpfiVZ7KQ==
+"@capture-models/types@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@capture-models/types/-/types-0.11.1.tgz#586901dbee31e164f1826597365a0fe746325e47"
+  integrity sha512-1ifMOJCX29LjR0TRIlmOG+qcZS7MgTMKkO3BpWgLwfflUF5dkFLFFtBjtAfwwCrvO+Jx1lN66wHCg/3RceEmfA==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"

--- a/services/storage-api/src/utility/typed-router.ts
+++ b/services/storage-api/src/utility/typed-router.ts
@@ -41,7 +41,15 @@ export class TypedRouter<
           this.router.put(
             route,
             path,
-            koaBody({ multipart: true, text: true, includeUnparsed: true, json: true, jsonLimit: '5mb', formLimit: '5mb', textLimit: '5mb' }),
+            koaBody({
+              multipart: true,
+              text: true,
+              includeUnparsed: true,
+              json: true,
+              jsonLimit: '5mb',
+              formLimit: '5mb',
+              textLimit: '5mb',
+            }),
             func
           );
           break;
@@ -50,7 +58,15 @@ export class TypedRouter<
           this.router.post(
             route,
             path,
-            koaBody({ multipart: true, text: true, includeUnparsed: true, json: true, jsonLimit: '5mb', formLimit: '5mb', textLimit: '5mb' }),
+            koaBody({
+              multipart: true,
+              text: true,
+              includeUnparsed: true,
+              json: true,
+              jsonLimit: '5mb',
+              formLimit: '5mb',
+              textLimit: '5mb',
+            }),
             func
           );
           break;
@@ -59,7 +75,15 @@ export class TypedRouter<
           this.router.patch(
             route,
             path,
-            koaBody({ multipart: true, text: true, includeUnparsed: true, json: true, jsonLimit: '5mb', formLimit: '5mb', textLimit: '5mb' }),
+            koaBody({
+              multipart: true,
+              text: true,
+              includeUnparsed: true,
+              json: true,
+              jsonLimit: '5mb',
+              formLimit: '5mb',
+              textLimit: '5mb',
+            }),
             func
           );
           break;


### PR DESCRIPTION
Adds the ability to import and edit plaintext OCR from seeAlso properties on IIIF resources.

1. Automatically fetches and imports plaintext OCR during import
2. Adds a new "data source" concept to capture models
3. Allows capture models to be configured to use the plaintext seeAlso property to pre-populate a field

## Data sources
This extension allows dynamic data sources to be defined and loaded when a capture model is created.

### Function of the extension
When a capture model is cloned, the following will happen:
- Detect if any of the fields in the capture model have data sources defined
- Load related code for generating data source, passing in the current resource and API
- Request the new value from the dynamic data source
- Return the model

### Persisting data on publish
This might not be in the scope of this but when data is saved (revision approved) then this extension
could detect and persist the linked properties back to the source. This is not current planned.


### Concrete use cases
In madoc there is a lot of sources of data that could be cycled like this in a project.

- Plain text transcriptions
- Canvas labels
- Metadata pairs
- Tags or JSON-LD documents that can be associated


### Plain text OCR
When you clone a capture model (from the one defined in a project to use on a specific canvas) it is pre-processed using this new "extension". The extension will look for configuration in the capture model that states that a particular field (like a text area) should have its value pre-populated by plaintext OCR. When one of these fields are found, the plain text is fetched and added to the field. 

#### Capture model editor
There is a new UI option when editing or adding a field in the capture model editor that lets you select which data source this should be populated from. (currently only plaintext)
<img width="425" alt="Screenshot 2020-12-23 at 18 54 24" src="https://user-images.githubusercontent.com/8266711/103028755-48710a00-4550-11eb-8563-274dda7e5822.png">

## Additional changes

**Made the import screen for manifests clearer. You will see search ingest progress, a collapsible list of canvases and any OCR import progress.**
<img width="1446" alt="Screenshot 2020-12-23 at 18 57 15" src="https://user-images.githubusercontent.com/8266711/103028955-ae5d9180-4550-11eb-83e3-7300420a26f3.png">

**OCR for a manifest is now found in its own tab on the resource**
<img width="1052" alt="Screenshot 2020-12-23 at 18 57 45" src="https://user-images.githubusercontent.com/8266711/103028986-bfa69e00-4550-11eb-8347-f883f7e4a379.png">

**Manifests can now be added project directly**
<img width="1462" alt="Screenshot 2020-12-23 at 18 58 29" src="https://user-images.githubusercontent.com/8266711/103029048-d9e07c00-4550-11eb-8f6d-42610a9cc997.png">

**Added more data to tasks pages in the admin, including the description, when the task was started, and any errors that may have occurred**