### PR TITLE
MAD-133 - viewing transcription

### DIFF
--- a/services/madoc-ts/src/extensions/capture-models/Paragraphs/Paragraphs.helpers.ts
+++ b/services/madoc-ts/src/extensions/capture-models/Paragraphs/Paragraphs.helpers.ts
@@ -40,7 +40,6 @@ export function preprocessCaptureModel(data: CaptureModel['document']['propertie
 }
 
 export type ParagraphEntity = CaptureModel['document'] & {
-  profile: typeof PARAGRAPHS_PROFILE;
   selector: BaseSelector;
   properties: {
     paragraph: Array<
@@ -60,6 +59,22 @@ export type ParagraphEntity = CaptureModel['document'] & {
     >;
   };
 };
+
+export function paragraphsToPlaintext(input: ParagraphEntity['properties']['paragraph']) {
+  const paragraphs = [];
+  for (const paragraph of input) {
+    const lines = [];
+    for (const line of paragraph.properties.lines) {
+      const texts = [];
+      for (const text of line.properties.text) {
+        texts.push(text.value);
+      }
+      lines.push(texts.join(' '));
+    }
+    paragraphs.push(lines.join('\n'));
+  }
+  return paragraphs.join('\n\n');
+}
 
 export function isParagraphEntity(entity: BaseField | CaptureModel['document']): entity is ParagraphEntity {
   if (!isEntity(entity)) {

--- a/services/madoc-ts/src/frontend/admin/pages/content/canvases/canvas-plaintext.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/content/canvases/canvas-plaintext.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useMutation } from 'react-query';
+import { Button } from '../../../../shared/atoms/Button';
+import { WarningMessage } from '../../../../shared/atoms/WarningMessage';
+import { useApi } from '../../../../shared/hooks/use-api';
+import { useData } from '../../../../shared/hooks/use-data';
+import { createUniversalComponent } from '../../../../shared/utility/create-universal-component';
+import { useParams } from 'react-router-dom';
+
+type CanvasPlaintextType = {
+  params: { id: string };
+  query: {};
+  variables: { id: number };
+  data: { found: boolean; transcription: string };
+};
+
+export const CanvasPlaintext = createUniversalComponent<CanvasPlaintextType>(
+  () => {
+    const { data } = useData(CanvasPlaintext, {}, { retry: 0 });
+
+    if (!data) {
+      return <div>loading...</div>;
+    }
+
+    return (
+      <div>
+        <h2>Plaintext transcription</h2>
+        {data.found ? <pre>{data.transcription}</pre> : <WarningMessage>Plaintext not found</WarningMessage>}
+      </div>
+    );
+  },
+  {
+    getKey: params => {
+      return ['canvas-search-index', { id: Number(params.id) }];
+    },
+    getData: async (key, { id }, api) => {
+      return await api.getCanvasPlaintext(id);
+    },
+  }
+);

--- a/services/madoc-ts/src/frontend/admin/pages/content/canvases/canvas-search-index.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/content/canvases/canvas-search-index.tsx
@@ -16,7 +16,7 @@ type CanvasSearchIndexType = {
 export const CanvasSearchIndex = createUniversalComponent<CanvasSearchIndexType>(
   () => {
     const { data, isError, refetch } = useData(CanvasSearchIndex, {}, { retry: 0 });
-    const { id } = useParams();
+    const { id } = useParams<{ id: string }>();
 
     const api = useApi();
     const [indexContext, { isLoading }] = useMutation(async () => {

--- a/services/madoc-ts/src/frontend/admin/pages/content/canvases/canvas.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/content/canvases/canvas.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { CanvasNavigation } from '../../../../shared/components/CanvasNavigation';
 import { UniversalComponent } from '../../../../types';
 import { LocaleString } from '../../../../shared/components/LocaleString';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams, useRouteMatch } from 'react-router-dom';
 import { renderUniversalRoutes } from '../../../../shared/utility/server-utils';
 import { CanvasFull } from '../../../../../types/schemas/canvas-full';
 import { useData } from '../../../../shared/hooks/use-data';
@@ -24,6 +25,9 @@ export const CanvasView: UniversalComponent<CanvasViewType> = createUniversalCom
   ({ route }) => {
     const { t } = useTranslation();
     const params = useParams<{ id: string; manifestId?: string }>();
+    const match = useRouteMatch();
+    const { pathname } = useLocation();
+    const subRoute = pathname.slice(match.url.length + 1);
     const { id, manifestId } = params;
     const { data } = useData(CanvasView);
     const { data: manifestResponse } = useApiManifest(manifestId);
@@ -77,9 +81,16 @@ export const CanvasView: UniversalComponent<CanvasViewType> = createUniversalCom
               label: t('search index'),
               link: manifestId ? `/manifests/${manifestId}/canvases/${id}/search` : `/canvases/${id}/search`,
             },
+            {
+              label: t('transcription'),
+              link: manifestId ? `/manifests/${manifestId}/canvases/${id}/plaintext` : `/canvases/${id}/plaintext`,
+            },
           ]}
         />
-        <WidePage>{renderUniversalRoutes(route.routes, { canvas, manifest: manifestResponse?.manifest })}</WidePage>
+        <WidePage>
+          {renderUniversalRoutes(route.routes, { canvas, manifest: manifestResponse?.manifest })}
+          <CanvasNavigation manifestId={manifestId} canvasId={id} admin subRoute={subRoute} />
+        </WidePage>
       </>
     );
   },

--- a/services/madoc-ts/src/frontend/admin/routes.tsx
+++ b/services/madoc-ts/src/frontend/admin/routes.tsx
@@ -1,4 +1,5 @@
 import { UniversalRoute } from '../types';
+import { CanvasPlaintext } from './pages/content/canvases/canvas-plaintext';
 import { CanvasSearchIndex } from './pages/content/canvases/canvas-search-index';
 import { CollectionView } from './pages/content/collections/collection';
 import { ViewCanvasLinking } from './pages/content/linking/view-linking';
@@ -122,6 +123,11 @@ export const routes: UniversalRoute[] = [
         exact: true,
         component: CanvasSearchIndex,
       },
+      {
+        path: '/manifests/:manifestId/canvases/:id/plaintext',
+        exact: true,
+        component: CanvasPlaintext,
+      },
     ],
   },
   {
@@ -198,6 +204,11 @@ export const routes: UniversalRoute[] = [
         path: '/canvases/:id/search',
         exact: true,
         component: CanvasSearchIndex,
+      },
+      {
+        path: '/canvases/:id/plaintext',
+        exact: true,
+        component: CanvasPlaintext,
       },
     ],
   },

--- a/services/madoc-ts/src/frontend/shared/components/CanvasNavigation.tsx
+++ b/services/madoc-ts/src/frontend/shared/components/CanvasNavigation.tsx
@@ -9,8 +9,9 @@ export const CanvasNavigation: React.FC<{
   projectId?: string | number;
   collectionId?: string | number;
   subRoute?: string;
+  admin?: boolean;
   query?: any;
-}> = ({ canvasId: id, manifestId, projectId, collectionId, subRoute, query }) => {
+}> = ({ canvasId: id, manifestId, projectId, collectionId, subRoute, admin, query }) => {
   const structure = useManifestStructure(manifestId);
 
   const idx = structure.data ? structure.data.ids.indexOf(Number(id)) : -1;
@@ -47,6 +48,7 @@ export const CanvasNavigation: React.FC<{
             canvasId: structure.data.items[idx + 1].id,
             subRoute,
             query,
+            admin,
           })}
           item={structure.data.items[idx + 1]}
         />

--- a/services/madoc-ts/src/frontend/site/pages/loaders/canvas-loader.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/loaders/canvas-loader.tsx
@@ -39,6 +39,7 @@ export type CanvasLoaderType = {
     refetchCanvasTasks: () => Promise<any>;
     refetchManifest: () => Promise<any>;
     isLoadingTasks: boolean;
+    plaintext?: string;
   };
 };
 
@@ -61,6 +62,7 @@ export const CanvasLoader: UniversalComponent<CanvasLoaderType> = createUniversa
           ...props,
           isLoadingTasks,
           canvas: data?.canvas,
+          plaintext: data?.plaintext,
           canvasTask: tasks?.canvasTask,
           userTasks: tasks?.userTasks,
           canUserSubmit: !!tasks?.canUserSubmit,
@@ -77,7 +79,7 @@ export const CanvasLoader: UniversalComponent<CanvasLoaderType> = createUniversa
       return ['getSiteCanvas', [Number(params.id)]];
     },
     getData: async (key, vars, api) => {
-      return api.getSiteCanvas(vars[0]);
+      return api.getSiteCanvas(vars[0], { plaintext: true });
     },
   }
 );

--- a/services/madoc-ts/src/frontend/site/pages/view-canvas.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/view-canvas.tsx
@@ -220,6 +220,7 @@ export const ViewCanvas: React.FC<ViewCanvasProps> = ({
   isLoadingTasks,
   manifest,
   collection,
+  plaintext,
 }) => {
   const { id, manifestId, collectionId } = useParams<{ id: string; manifestId?: string; collectionId?: string }>();
   const [canvasRef, setCanvasRef] = useState<CanvasNormalized>();
@@ -396,6 +397,13 @@ export const ViewCanvas: React.FC<ViewCanvasProps> = ({
       )}
 
       <MetaDataDisplay metadata={(manifest && manifest.metadata) || []} />
+
+      {plaintext ? (
+        <>
+          <h4>Transcription</h4>
+          <pre>{plaintext}</pre>
+        </>
+      ) : null}
     </>
   );
 };

--- a/services/madoc-ts/src/gateway/api.ts
+++ b/services/madoc-ts/src/gateway/api.ts
@@ -92,6 +92,9 @@ export class ApiClient {
   }
 
   resolveUrl(pathName: string) {
+    if (pathName.startsWith('/')) {
+      return `${this.gateway}${pathName}`;
+    }
     return `${this.gateway}/${pathName}`;
   }
 
@@ -656,8 +659,13 @@ export class ApiClient {
   async getCanvasMetadata(id: number) {
     return this.request<GetMetadata>(`/api/madoc/iiif/canvases/${id}/metadata`);
   }
+
   async getCanvasLinking(id: number) {
     return this.request<{ linking: ResourceLinkResponse[] }>(`/api/madoc/iiif/canvases/${id}/linking`);
+  }
+
+  async getCanvasPlaintext(id: number) {
+    return this.request<{ found: boolean; transcription: string }>(`/api/madoc/iiif/canvases/${id}/plaintext`);
   }
 
   async getLinkingProperty(id: number) {

--- a/services/madoc-ts/src/gateway/tasks/process-manifest-ocr.ts
+++ b/services/madoc-ts/src/gateway/tasks/process-manifest-ocr.ts
@@ -1,3 +1,5 @@
+import { ResourceLinkResponse } from '../../database/queries/linking-queries';
+import { isLinkHocr, isLinkMetsAlto, isLinkPlaintext } from '../../utility/linking-property-types';
 import { BaseTask } from './base-task';
 import * as importCanvas from './import-canvas';
 import * as tasks from './task-helpers';
@@ -63,11 +65,7 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
         }
 
         // META+ALTO detection.
-        if (
-          (link.link.format === 'text/xml' || link.link.format === 'application/xml+alto') &&
-          link.link.profile &&
-          link.link.profile.startsWith('http://www.loc.gov/standards/alto/')
-        ) {
+        if (isLinkMetsAlto(link)) {
           // Make sure we don't add it twice.
           spendIds.push(link.resource_id);
           // Create task.
@@ -85,13 +83,7 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
         }
 
         // hOCR detection
-        if (
-          link.link.format === 'text/vnd.hocr+html' &&
-          link.link.profile &&
-          (link.link.profile.startsWith('http://kba.cloud/hocr-spec') ||
-            link.link.profile.startsWith('http://kba.github.io/hocr-spec/') ||
-            link.link.profile === 'https://github.com/kba/hocr-spec/blob/master/hocr-spec.md')
-        ) {
+        if (isLinkHocr(link)) {
           // Make sure we don't add it twice.
           spendIds.push(link.resource_id);
           // Create task.
@@ -109,7 +101,7 @@ export const jobHandler = async (name: string, taskId: string, api: ApiClient) =
         }
 
         // Plain text detection
-        if (link.link.format === 'text/plain') {
+        if (isLinkPlaintext(link)) {
           // Be sure not to add it twice.
           spendIds.push(link.resource_id);
           // Create task if the linked file is not already stored.

--- a/services/madoc-ts/src/router.ts
+++ b/services/madoc-ts/src/router.ts
@@ -2,6 +2,7 @@ import { exportSite } from './routes/admin/export-site';
 import { importSite } from './routes/admin/import-site';
 import { getSiteDetails } from './routes/admin/site-details';
 import { updateSiteConfiguration } from './routes/admin/update-site-configuration';
+import { getCanvasPlaintext } from './routes/iiif/canvases/get-canvas-plaintext';
 import { batchIndex } from './routes/search/batch-index';
 import { siteConfiguration } from './routes/site/site-configuration';
 import { convertLinking } from './routes/iiif/linking/convert-linking';
@@ -172,6 +173,7 @@ export const router = new TypedRouter({
   'get-canvas-linking': [TypedRouter.GET, '/api/madoc/iiif/canvases/:id/linking', getLinking],
   'search-index-canvas': [TypedRouter.POST, '/api/madoc/iiif/canvases/:id/index', indexCanvas],
   'convert-linking-property': [TypedRouter.POST, '/api/madoc/iiif/linking/:id/convert', convertLinking],
+  'get-canvas-plaintext': [TypedRouter.GET, '/api/madoc/iiif/canvases/:id/plaintext', getCanvasPlaintext],
 
   // Import API
   'import-manifest': [TypedRouter.POST, '/api/madoc/iiif/import/manifest', importManifest],

--- a/services/madoc-ts/src/routes/iiif/canvases/get-canvas-plaintext.ts
+++ b/services/madoc-ts/src/routes/iiif/canvases/get-canvas-plaintext.ts
@@ -1,0 +1,94 @@
+import { traverseDocument } from '@capture-models/helpers';
+import {
+  paragraphsToPlaintext,
+  PARAGRAPHS_PROFILE,
+} from '../../../extensions/capture-models/Paragraphs/Paragraphs.helpers';
+import { api } from '../../../gateway/api.server';
+import { RouteMiddleware } from '../../../types/route-middleware';
+import { isLinkCaptureModelParagraphs, isLinkPlaintext } from '../../../utility/linking-property-types';
+import { userWithScope } from '../../../utility/user-with-scope';
+
+export const getCanvasPlaintext: RouteMiddleware<{ id: string }> = async context => {
+  const { siteId } = userWithScope(context, []);
+  const siteApi = api.asUser({ siteId });
+
+  // Get all capture models.
+  const models = await siteApi.getAllCaptureModels({
+    target_id: `urn:madoc:canvas:${context.params.id}`,
+    target_type: 'Canvas',
+    all_derivatives: true,
+  });
+
+  const state: { found: boolean; transcription?: string; source?: string } = {
+    found: false,
+    transcription: undefined,
+    source: undefined,
+  };
+
+  if (models.length) {
+    for (const model of models) {
+      if (state.found) break;
+      const loadedModel = await siteApi.getCaptureModel(model.id, { published: true });
+      traverseDocument(loadedModel.document, {
+        visitField(field) {
+          // Capture model data source (text plain)
+          if (
+            !state.found &&
+            field.dataSources &&
+            field.dataSources.indexOf('plaintext-source') !== -1 &&
+            field.value
+          ) {
+            // We have a transcription!
+            state.found = true;
+            if (field.type === 'html') {
+              // @todo strip HTML?
+            }
+            state.transcription = field.value;
+          }
+        },
+
+        visitEntity(entity, key, parent) {
+          // Capture model OCR
+          if (!state.found && entity.profile === PARAGRAPHS_PROFILE && parent && key) {
+            // We have a paragraphs tree.
+            state.found = true;
+            state.transcription = paragraphsToPlaintext(parent.properties[key] as any);
+          }
+        },
+      });
+    }
+  }
+
+  if (!state.found) {
+    const linkingProperties = await siteApi.getCanvasLinking(Number(context.params.id));
+
+    for (const linkingProperty of linkingProperties.linking) {
+      if (linkingProperty.property === 'seeAlso' && isLinkPlaintext(linkingProperty)) {
+        if (linkingProperty.file) {
+          const resolvedParagraphs = api.resolveUrl(linkingProperty.link.id);
+          const transcription = await fetch(resolvedParagraphs).then(r => r.text());
+
+          if (transcription) {
+            state.found = true;
+            state.transcription = transcription;
+          }
+        }
+      }
+      if (linkingProperty.property === 'seeAlso' && isLinkCaptureModelParagraphs(linkingProperty)) {
+        if (linkingProperty.file) {
+          const resolvedParagraphs = api.resolveUrl(linkingProperty.link.id);
+          const transcription = await fetch(resolvedParagraphs)
+            .then(r => r.json())
+            .then(r => paragraphsToPlaintext(r.paragraph));
+
+          if (transcription) {
+            state.found = true;
+            state.transcription = transcription;
+          }
+        }
+      }
+    }
+  }
+
+  context.response.body = state;
+};

--- a/services/madoc-ts/src/routes/site/site-canvas.ts
+++ b/services/madoc-ts/src/routes/site/site-canvas.ts
@@ -1,10 +1,12 @@
 import { RouteMiddleware } from '../../types/route-middleware';
+import { castBool } from '../../utility/cast-bool';
 
 export type SiteCanvasQuery = {
   manifest_id?: number;
   collection_id?: number;
   parent_collection_ids?: number[];
   project_id?: number;
+  plaintext?: boolean;
 };
 
 export const siteCanvas: RouteMiddleware<{ slug: string; id: string }> = async context => {
@@ -20,6 +22,13 @@ export const siteCanvas: RouteMiddleware<{ slug: string; id: string }> = async c
   // return collection id.
   context.response.status = 200;
   context.response.body = canvas;
+
+  if (castBool(context.query.plaintext)) {
+    const plaintext = await siteApi.getCanvasPlaintext(Number(canvasId));
+    if (plaintext.found) {
+      context.response.body.plaintext = plaintext.transcription;
+    }
+  }
 
   return;
 };

--- a/services/madoc-ts/src/types/schemas/canvas-full.ts
+++ b/services/madoc-ts/src/types/schemas/canvas-full.ts
@@ -13,4 +13,5 @@ export type CanvasFull = {
     source?: any;
     duration?: number;
   };
+  plaintext?: string;
 };

--- a/services/madoc-ts/src/utility/linking-property-types.ts
+++ b/services/madoc-ts/src/utility/linking-property-types.ts
@@ -1,0 +1,40 @@
+import { ResourceLinkResponse } from '../database/queries/linking-queries';
+import { PARAGRAPHS_PROFILE } from '../extensions/capture-models/Paragraphs/Paragraphs.helpers';
+
+export function isLinkMetsAlto(link: ResourceLinkResponse) {
+  return (
+    (link.link.format === 'text/xml' || link.link.format === 'application/xml+alto') &&
+    link.link.profile &&
+    link.link.profile.startsWith('http://www.loc.gov/standards/alto/')
+  );
+}
+
+export function isLinkHocr(link: ResourceLinkResponse) {
+  return (
+    link.link.format === 'text/vnd.hocr+html' &&
+    link.link.profile &&
+    (link.link.profile.startsWith('http://kba.cloud/hocr-spec') ||
+      link.link.profile.startsWith('http://kba.github.io/hocr-spec/') ||
+      link.link.profile === 'https://github.com/kba/hocr-spec/blob/master/hocr-spec.md')
+  );
+}
+
+export function isLinkPlaintext(link: ResourceLinkResponse) {
+  return link.link.format === 'text/plain';
+}
+
+export function isLinkCaptureModelParagraphs(link: ResourceLinkResponse) {
+  return (
+    link.link.format === 'application/json' &&
+    link.link.type === 'CaptureModelDocument' &&
+    link.link.profile === PARAGRAPHS_PROFILE
+  );
+}
+
+export function isLinkLocalOcr(link: ResourceLinkResponse) {
+  return isLinkPlaintext(link) || isLinkCaptureModelParagraphs(link);
+}
+
+export function isLinkOcr(link: ResourceLinkResponse) {
+  return isLinkPlaintext(link) || isLinkHocr(link) || isLinkMetsAlto(link);
+}


### PR DESCRIPTION
This will resolve the transcription from one of four places:
* Capture model data source (text plain) - newly added today
* Published capture model paragraphs - from OCR transformation
* Plaintext `seeAlso` linking property, but only if it has been stored in Madoc
* Intermediate paragraphs format in the `seeAlso`

There is a backend API for getting this data and also links into the frontend for loading canvases. Caching needs revisited on this.

## Admin transcription
<img width="1451" alt="Screenshot 2020-12-23 at 23 15 28" src="https://user-images.githubusercontent.com/8266711/103043427-c1825880-4574-11eb-8ab4-887faa3c0b8a.png">
