### PR TITLE
MAD-475 user dashboard

### DIFF
--- a/services/madoc-ts/src/frontend/admin/index.tsx
+++ b/services/madoc-ts/src/frontend/admin/index.tsx
@@ -1,19 +1,25 @@
 import React, { useMemo } from 'react';
 import { ApiClient } from '../../gateway/api';
 import { useTranslation } from 'react-i18next';
+import { PublicSite } from '../../utility/omeka-api';
+import { GlobalStyles } from '../shared/atoms/GlobalStyles';
+import { UserBar } from '../shared/components/UserBar';
 import { renderUniversalRoutes } from '../shared/utility/server-utils';
 import { ApiContext, useIsApiRestarting } from '../shared/hooks/use-api';
 import { ErrorMessage } from '../shared/atoms/ErrorMessage';
 import { UniversalRoute } from '../types';
 import '../shared/caputre-models/plugins';
+import { SiteProvider } from '../shared/hooks/use-site';
 
 export type AdminAppProps = {
   jwt?: string;
   api: ApiClient;
   routes: UniversalRoute[];
+  user: { name: string; id: number };
+  site: PublicSite;
 };
 
-const AdminApp: React.FC<AdminAppProps> = ({ api, routes }) => {
+const AdminApp: React.FC<AdminAppProps> = ({ api, routes, site, user }) => {
   const { i18n } = useTranslation();
   const restarting = useIsApiRestarting(api);
 
@@ -21,8 +27,12 @@ const AdminApp: React.FC<AdminAppProps> = ({ api, routes }) => {
 
   return (
     <div lang={i18n.language} dir={viewingDirection}>
-      {restarting ? <ErrorMessage>Lost connection to server, retrying... </ErrorMessage> : null}
-      <ApiContext.Provider value={api}>{renderUniversalRoutes(routes)}</ApiContext.Provider>
+      <SiteProvider value={useMemo(() => ({ site, user }), [site, user])}>
+        <GlobalStyles />
+        <UserBar site={site} user={user} admin />
+        {restarting ? <ErrorMessage>Lost connection to server, retrying... </ErrorMessage> : null}
+        <ApiContext.Provider value={api}>{renderUniversalRoutes(routes)}</ApiContext.Provider>
+      </SiteProvider>
     </div>
   );
 };

--- a/services/madoc-ts/src/frontend/admin/molecules/AdminHeader.tsx
+++ b/services/madoc-ts/src/frontend/admin/molecules/AdminHeader.tsx
@@ -6,6 +6,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { WidePage } from '../../shared/atoms/WidePage';
 import { SearchBox } from '../../shared/atoms/SearchBox';
 import { GridContainer } from '../../shared/atoms/Grid';
+import { useSite } from '../../shared/hooks/use-site';
 
 const AdminHeaderBackground = styled.div`
   background: #25416b;

--- a/services/madoc-ts/src/frontend/admin/pages/homepage.tsx
+++ b/services/madoc-ts/src/frontend/admin/pages/homepage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSite } from '../../shared/hooks/use-site';
 import { UniversalComponent } from '../../types';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
@@ -55,6 +56,7 @@ const Homepage: UniversalComponent<HomepageType> = createUniversalComponent<Home
   () => {
     const { data: stats } = useStaticData(Homepage);
     const { t } = useTranslation();
+    const site = useSite();
 
     return (
       <div>
@@ -75,6 +77,9 @@ const Homepage: UniversalComponent<HomepageType> = createUniversalComponent<Home
             <AdminSection>
               <MenuTitle>Content</MenuTitle>
               <MenuList>
+                <li>
+                  <a href={`/admin/site/s/${site.slug}/show/`}>{t('Omeka admin')}</a>
+                </li>
                 <li>
                   <Link to="/collections">{t('Manage collections')}</Link>
                 </li>

--- a/services/madoc-ts/src/frontend/admin/server.tsx
+++ b/services/madoc-ts/src/frontend/admin/server.tsx
@@ -14,4 +14,4 @@ import { createServerRenderer } from '../shared/utility/create-server-renderer';
 
 const apiGateway = process.env.API_GATEWAY as string;
 
-export const render = createServerRenderer(AdminApp, routes, apiGateway, queryConfig);
+export const render = createServerRenderer(AdminApp as any, routes, apiGateway, queryConfig);

--- a/services/madoc-ts/src/frontend/shared/atoms/Breadcrumbs.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/Breadcrumbs.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { BreadcrumbDivider, BreadcrumbList, BreadcrumbItem as SiteBreadcrumbItem } from '../components/Breadcrumbs';
 import { LocaleString } from '../components/LocaleString';
+import { useSite } from '../hooks/use-site';
 
 export type BreadcrumbItem = {
   label: string | any;
@@ -53,6 +54,7 @@ export const Breadcrumbs: React.FC<{
   padding?: string;
 }> = ({ items: rawItems, type, background, color, $activeColor, padding }) => {
   const items: BreadcrumbItem[] = useMemo(() => rawItems.filter(r => r) as BreadcrumbItem[], [rawItems]);
+  const site = useSite();
 
   if (items.length === 0) {
     return null;
@@ -75,12 +77,20 @@ export const Breadcrumbs: React.FC<{
 
   return (
     <BreadcrumbContainer background={background} color={color} padding={padding}>
+      <BreadcrumbItem active>
+        <a style={{ color: '#fff' }} href={`/s/${site.slug}/madoc`}>
+          Back to site
+        </a>
+      </BreadcrumbItem>
+      <BreadcrumbSeparator color={color}>{`/`}</BreadcrumbSeparator>
       {items.map((item, n) => {
         return (
           <React.Fragment key={item.link}>
             {n !== 0 ? <BreadcrumbSeparator color={color}>{`/`}</BreadcrumbSeparator> : null}
             <BreadcrumbItem key={item.link} active={item.active} color={color} $activeColor={$activeColor}>
-              <Link to={item.link} title={item.label}>{item.label}</Link>
+              <Link to={item.link} title={item.label}>
+                {item.label}
+              </Link>
             </BreadcrumbItem>
           </React.Fragment>
         );

--- a/services/madoc-ts/src/frontend/shared/atoms/GlobalStyles.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/GlobalStyles.tsx
@@ -1,0 +1,26 @@
+import { createGlobalStyle } from "styled-components";
+
+export const GlobalStyles = createGlobalStyle`
+  html, body {
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
+    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  }
+
+  *, *:before, *:after {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+
+  body {
+    display: flex;
+    flex-direction: column;
+    background: #fff; /* Body background */
+  }
+
+  a {
+    color: #333;
+  }
+`;

--- a/services/madoc-ts/src/frontend/shared/atoms/Heading2.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/Heading2.tsx
@@ -1,0 +1,12 @@
+import styled, { css } from 'styled-components';
+
+export const Heading2 = styled.h2<{ $margin?: boolean }>`
+  font-size: 1.75em;
+  font-weight: 600;
+  margin-bottom: 0.2em;
+  ${props =>
+    props.$margin &&
+    css`
+      margin-bottom: 1em;
+    `}
+`;

--- a/services/madoc-ts/src/frontend/shared/atoms/SiteContainer.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/SiteContainer.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const SiteContainer = styled.div`
+  flex: 1 1 0;
+  max-width: 1440px;
+  padding: 0 2em;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+`;

--- a/services/madoc-ts/src/frontend/shared/components/UserBar.tsx
+++ b/services/madoc-ts/src/frontend/shared/components/UserBar.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import styled from 'styled-components';
+import { PublicSite } from '../../../utility/omeka-api';
+import { HrefLink } from '../utility/href-link';
+
+const UserBarContainer = styled.div`
+  position: absolute;
+  height: 36px;
+  background: #333;
+  left: 0;
+  right: 0;
+  top: 0;
+  color: #fff;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  z-index: 10;
+  padding: 0 18px;
+`;
+
+const UserBarAdminButton = styled.a`
+  text-decoration: none;
+  color: #fff;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const UserBarExpander = styled.div`
+  flex: 1 1 0px;
+`;
+
+const UserBarSpacer = styled.div`
+  position: relative;
+  height: 36px;
+  display: block;
+`;
+
+const UserBarUserDetails = styled.span`
+  font-size: 13px;
+  margin-right: 10px;
+  color: rgba(255, 255, 255, 0.5);
+  a {
+    color: #fff;
+    text-decoration: underline;
+  }
+`;
+
+const UserBarLogout = styled.span`
+  font-size: 13px;
+  a {
+    color: #fff;
+    text-decoration: underline;
+  }
+`;
+
+export const UserBar: React.FC<{ site: PublicSite; user?: { name: string; id: number }; admin?: boolean }> = ({
+  user,
+  site,
+  admin,
+}) => {
+  return (
+    <>
+      <UserBarContainer>
+        <UserBarAdminButton href={`/s/${site.slug}/madoc/admin`}>Site admin</UserBarAdminButton>
+        <UserBarExpander />
+        {user ? (
+          <>
+            <UserBarUserDetails>
+              Signed in as{' '}
+              {admin ? (
+                <a href={`/s/${site.slug}/madoc/dashboard`}>{user.name}</a>
+              ) : (
+                <HrefLink href="/dashboard">{user.name}</HrefLink>
+              )}
+            </UserBarUserDetails>
+            <UserBarLogout>
+              <a href={`/s/${site.slug}/madoc/logout`}>Logout</a>
+            </UserBarLogout>
+          </>
+        ) : (
+          <UserBarLogout>
+            <a href={`/s/${site.slug}/madoc/login`}>Log in</a>
+          </UserBarLogout>
+        )}
+      </UserBarContainer>
+      <UserBarSpacer />
+    </>
+  );
+};

--- a/services/madoc-ts/src/frontend/shared/hooks/use-site.ts
+++ b/services/madoc-ts/src/frontend/shared/hooks/use-site.ts
@@ -1,0 +1,20 @@
+import React, { useContext } from 'react';
+import { PublicSite } from '../../../utility/omeka-api';
+
+const SiteReactContext = React.createContext<{ site: PublicSite; user?: { id: number; name: string } } | undefined>(
+  undefined
+);
+
+export const useSite = () => {
+  const details = useContext(SiteReactContext);
+
+  return details?.site as PublicSite;
+};
+
+export const useUser = () => {
+  const details = useContext(SiteReactContext);
+
+  return details?.user;
+};
+
+export const SiteProvider = SiteReactContext.Provider;

--- a/services/madoc-ts/src/frontend/shared/utility/render-client.tsx
+++ b/services/madoc-ts/src/frontend/shared/utility/render-client.tsx
@@ -26,7 +26,9 @@ export function renderClient(
 ) {
   const component = document.getElementById('react-component');
   const dehydratedStateEl = document.getElementById('react-query-cache');
+  const dehydratedSiteEl = document.getElementById('react-omeka');
   const dehydratedState = dehydratedStateEl ? JSON.parse(dehydratedStateEl.innerText) : {};
+  const dehydratedSite = dehydratedSiteEl ? JSON.parse(dehydratedSiteEl.innerText) : {};
 
   const [, slug] = window.location.pathname.match(/s\/([^/]*)/) as string[];
   const jwt = cookies.get(`madoc/${slug}`) || undefined;
@@ -49,7 +51,14 @@ export function renderClient(
                 <BrowserRouter basename={basename}>
                   <DndProvider backend={MultiBackend} options={HTML5toTouch}>
                     <ErrorBoundary onError={error => <ErrorPage error={error} />}>
-                      <Component jwt={jwt} api={api} routes={routes} />
+                      <Component
+                        jwt={jwt}
+                        api={api}
+                        routes={routes}
+                        siteSlug={slug}
+                        site={dehydratedSite.site}
+                        user={dehydratedSite.user}
+                      />
                       {process.env.NODE_ENV === 'development' ? <ReactQueryDevtools /> : null}
                     </ErrorBoundary>
                   </DndProvider>

--- a/services/madoc-ts/src/frontend/site/components.tsx
+++ b/services/madoc-ts/src/frontend/site/components.tsx
@@ -22,3 +22,6 @@ export { ViewManifestMirador } from './pages/view-manifest-mirador';
 export { ViewUser } from './pages/view-user';
 export { RootLoader } from './pages/loaders/root-loader';
 export { ProjectListLoader } from './pages/loaders/project-list-loader';
+export { UserDashboard } from './pages/dashboard/dashboard';
+export { UserContributions } from './pages/dashboard/user-contributions';
+export { UserReviews } from './pages/dashboard/user-reviews';

--- a/services/madoc-ts/src/frontend/site/components.tsx
+++ b/services/madoc-ts/src/frontend/site/components.tsx
@@ -25,3 +25,4 @@ export { ProjectListLoader } from './pages/loaders/project-list-loader';
 export { UserDashboard } from './pages/dashboard/dashboard';
 export { UserContributions } from './pages/dashboard/user-contributions';
 export { UserReviews } from './pages/dashboard/user-reviews';
+export { Homepage } from './pages/homepage';

--- a/services/madoc-ts/src/frontend/site/features/GlobalSiteHeader.tsx
+++ b/services/madoc-ts/src/frontend/site/features/GlobalSiteHeader.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
+import { ErrorMessage } from '../../shared/atoms/ErrorMessage';
+import { GlobalStyles } from '../../shared/atoms/GlobalStyles';
+import { useApi, useIsApiRestarting } from '../../shared/hooks/use-api';
+import { useSite } from '../../shared/hooks/use-site';
+import { HrefLink } from '../../shared/utility/href-link';
+
+const SiteHeader = styled.div`
+  max-width: 1440px;
+  width: 100%;
+  padding: 0 2em;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  background: #fff;
+`;
+
+const SiteDetails = styled.div`
+  align-self: flex-start;
+  text-decoration: none;
+  flex: 1 1 0px;
+`;
+
+const SiteTitle = styled.a`
+  text-decoration: none;
+  letter-spacing: -2px;
+  color: #363453;
+  font-size: 1em;
+`;
+
+const GlobalSearchContainer = styled.div`
+  flex: 1;
+  margin-right: 20px;
+  width: 100%;
+  max-width: 20em;
+`;
+
+const GlobalSearchForm = styled.form`
+  display: flex;
+  margin-bottom: 0;
+`;
+
+const GlobalSearchInput = styled.input`
+  font-size: 0.9em;
+  padding: 0.5em;
+  border: 2px solid #c2c2c2;
+  border-right: none;
+  border-radius: 0;
+  width: 100%;
+
+  &:focus {
+    border-color: #333;
+    outline: none;
+  }
+`;
+
+const GlobalSearchButton = styled.button`
+  font-size: 0.9em;
+  padding: 0.2em 1em;
+  background: #333;
+  color: #fff;
+  border: 2px solid #333;
+`;
+
+export const GlobalSiteHeader: React.FC = () => {
+  const site = useSite();
+  const api = useApi();
+  const restarting = useIsApiRestarting(api);
+  const history = useHistory();
+  const [query, setQuery] = useState('');
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {restarting ? <ErrorMessage>Lost connection to server, retrying... </ErrorMessage> : null}
+      <GlobalStyles />
+      <SiteHeader>
+        <SiteDetails>
+          <SiteTitle as={HrefLink} href={`/`} className="site-title">
+            <h1>
+              <span className="title">{site.title}</span>
+            </h1>
+          </SiteTitle>
+        </SiteDetails>
+        <GlobalSearchContainer>
+          <GlobalSearchForm
+            onSubmit={e => {
+              e.preventDefault();
+              history.push(`/search?fulltext=${query}`);
+              setQuery('');
+            }}
+          >
+            <GlobalSearchInput
+              type="text"
+              name="fulltext"
+              value={query}
+              onChange={e => {
+                setQuery(e.target.value);
+              }}
+              placeholder={t('Search')}
+            />
+            <GlobalSearchButton type="submit">{t('Search')}</GlobalSearchButton>
+          </GlobalSearchForm>
+        </GlobalSearchContainer>
+      </SiteHeader>
+    </>
+  );
+};

--- a/services/madoc-ts/src/frontend/site/features/GlobalSiteNavigation.tsx
+++ b/services/madoc-ts/src/frontend/site/features/GlobalSiteNavigation.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { LightNavigation, LightNavigationItem } from '../../shared/atoms/LightNavigation';
+import { useUser } from '../../shared/hooks/use-site';
+import { HrefLink } from '../../shared/utility/href-link';
+
+export const GlobalSiteNavigation: React.FC = () => {
+  const history = useHistory();
+  const user = useUser();
+
+  return (
+    <LightNavigation style={{ marginBottom: 15 }}>
+      <LightNavigationItem $active={history.location.pathname === '/projects'}>
+        <HrefLink href="/projects">Projects</HrefLink>
+      </LightNavigationItem>
+      <LightNavigationItem $active={history.location.pathname === '/collections'}>
+        <HrefLink href="/collections">Collections</HrefLink>
+      </LightNavigationItem>
+      <LightNavigationItem $active={history.location.pathname === '/manifests'}>
+        <HrefLink href="/manifests">Manifests</HrefLink>
+      </LightNavigationItem>
+      {user ? (
+        <LightNavigationItem $active={history.location.pathname.startsWith('/dashboard')}>
+          <HrefLink href="/dashboard">User dashboard</HrefLink>
+        </LightNavigationItem>
+      ) : null}
+    </LightNavigation>
+  );
+};

--- a/services/madoc-ts/src/frontend/site/features/UserGreeting.tsx
+++ b/services/madoc-ts/src/frontend/site/features/UserGreeting.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Heading1 } from '../../shared/atoms/Heading1';
+import { Heading2 } from '../../shared/atoms/Heading2';
 import { useUserHomepage } from '../hooks/use-user-homepage';
 
 export const UserGreeting: React.FC = () => {
@@ -9,5 +9,5 @@ export const UserGreeting: React.FC = () => {
     return null;
   }
 
-  return <Heading1>Welcome back {data.userDetails.user.name}</Heading1>;
+  return <Heading2 $margin>Welcome back {data.userDetails.user.name}</Heading2>;
 };

--- a/services/madoc-ts/src/frontend/site/index.tsx
+++ b/services/madoc-ts/src/frontend/site/index.tsx
@@ -1,31 +1,50 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import styled from 'styled-components';
 import { ApiClient } from '../../gateway/api';
 import { useTranslation } from 'react-i18next';
+import { PublicSite } from '../../utility/omeka-api';
+import { GlobalStyles } from '../shared/atoms/GlobalStyles';
+import { LightNavigation, LightNavigationItem } from '../shared/atoms/LightNavigation';
+import { SiteContainer } from '../shared/atoms/SiteContainer';
+import { UserBar } from '../shared/components/UserBar';
+import { HrefLink } from '../shared/utility/href-link';
 import { renderUniversalRoutes } from '../shared/utility/server-utils';
 import { ApiContext, useIsApiRestarting } from '../shared/hooks/use-api';
 import { ErrorMessage } from '../shared/atoms/ErrorMessage';
 import { UniversalRoute } from '../types';
 import { VaultProvider } from '@hyperion-framework/react-vault';
 import '../shared/caputre-models/plugins';
+import { SiteProvider } from '../shared/hooks/use-site';
+import { GlobalSiteHeader } from './features/GlobalSiteHeader';
+import { GlobalSiteNavigation } from './features/GlobalSiteNavigation';
 
 export type SiteAppProps = {
   jwt?: string;
   api: ApiClient;
   routes: UniversalRoute[];
+  siteSlug?: string;
+  user?: { name: string; id: number };
+  site: PublicSite;
 };
 
-const SiteApp: React.FC<SiteAppProps> = ({ api, routes }) => {
+const SiteApp: React.FC<SiteAppProps> = ({ api, site, user, routes }) => {
   const { i18n } = useTranslation();
-  const restarting = useIsApiRestarting(api);
 
   const viewingDirection = useMemo(() => i18n.dir(i18n.language), [i18n]);
 
   return (
     <VaultProvider>
-      <div lang={i18n.language} dir={viewingDirection}>
-        {restarting ? <ErrorMessage>Lost connection to server, retrying... </ErrorMessage> : null}
-        <ApiContext.Provider value={api}>{renderUniversalRoutes(routes)}</ApiContext.Provider>
-      </div>
+      <SiteProvider value={useMemo(() => ({ site, user }), [user, site])}>
+        <ApiContext.Provider value={api}>
+          <UserBar site={site} user={user} />
+          <GlobalSiteHeader />
+          <SiteContainer lang={i18n.language} dir={viewingDirection}>
+            <GlobalSiteNavigation />
+            {renderUniversalRoutes(routes)}
+          </SiteContainer>
+        </ApiContext.Provider>
+      </SiteProvider>
     </VaultProvider>
   );
 };

--- a/services/madoc-ts/src/frontend/site/pages/dashboard/dashboard.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/dashboard/dashboard.tsx
@@ -1,7 +1,4 @@
 import React from 'react';
-import { ContributorTasks } from '../../features/ContributorTasks';
-import { ReviewerTasks } from '../../features/ReviewerTasks';
-import { UserGreeting } from '../../features/UserGreeting';
 import { UserProjects } from '../../features/UserProjects';
 import { UserStatistics } from '../../features/UserStatistics';
 

--- a/services/madoc-ts/src/frontend/site/pages/dashboard/dashboard.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/dashboard/dashboard.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ContributorTasks } from '../../features/ContributorTasks';
+import { ReviewerTasks } from '../../features/ReviewerTasks';
+import { UserGreeting } from '../../features/UserGreeting';
+import { UserProjects } from '../../features/UserProjects';
+import { UserStatistics } from '../../features/UserStatistics';
+
+export const UserDashboard: React.FC = () => {
+  return (
+    <>
+      <UserStatistics />
+
+      <UserProjects />
+    </>
+  );
+};

--- a/services/madoc-ts/src/frontend/site/pages/dashboard/user-contributions.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/dashboard/user-contributions.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ContributorTasks } from '../../features/ContributorTasks';
+import { ReviewerTasks } from '../../features/ReviewerTasks';
+
+export const UserContributions: React.FC = () => {
+  return (
+    <>
+      <ContributorTasks />
+    </>
+  );
+};

--- a/services/madoc-ts/src/frontend/site/pages/dashboard/user-reviews.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/dashboard/user-reviews.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ReviewerTasks } from '../../features/ReviewerTasks';
+
+export const UserReviews: React.FC = () => {
+  return (
+    <>
+      <ReviewerTasks />
+    </>
+  );
+};

--- a/services/madoc-ts/src/frontend/site/pages/homepage.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/homepage.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { HrefLink } from '../../shared/utility/href-link';
+
+export const Homepage: React.FC = () => {
+  return (
+    <div>
+      <h1>Homepage</h1>
+      <p>We are working on features for customising the homepage.</p>
+      <ul>
+        <li>
+          <HrefLink href="/collections">All collections</HrefLink>
+        </li>
+        <li>
+          <HrefLink href="/projects">All projects</HrefLink>
+        </li>
+        <li>
+          <HrefLink href="/manifests">All manifests</HrefLink>
+        </li>
+        <li>
+          <HrefLink href="/dashboard">User dashboard (login required)</HrefLink>
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/services/madoc-ts/src/frontend/site/pages/user-homepage.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/user-homepage.tsx
@@ -19,6 +19,7 @@ import { UserGreeting } from '../features/UserGreeting';
 import { UserProjects } from '../features/UserProjects';
 import { UserStatistics } from '../features/UserStatistics';
 import { useRelativeLinks } from '../hooks/use-relative-links';
+import { useSite } from '../../shared/hooks/use-site';
 import { useUserHomepage } from '../hooks/use-user-homepage';
 
 type UserHomepageType = {
@@ -41,8 +42,10 @@ export const UserHomepage: UniversalComponent<UserHomepageType> = createUniversa
   ({ route }) => {
     const { data, error } = useStaticData(UserHomepage, {}, { retry: false });
     const location = useLocation();
+    const { slug } = useSite();
 
     const showReviews = data && isReviewer(data.userDetails);
+    const showAdmin = data && isAdmin(data.userDetails);
 
     if (error) {
       return <a href="/login">Please login</a>;
@@ -58,8 +61,8 @@ export const UserHomepage: UniversalComponent<UserHomepageType> = createUniversa
         <UserGreeting />
 
         <DashboardTabs>
-          <DashboardTab $active={location.pathname === '/'}>
-            <HrefLink href="/">Overview</HrefLink>
+          <DashboardTab $active={location.pathname === '/dashboard'}>
+            <HrefLink href="/dashboard">Overview</HrefLink>
           </DashboardTab>
           <DashboardTab $active={location.pathname === '/dashboard/contributions'}>
             <HrefLink href="/dashboard/contributions">Contributions</HrefLink>
@@ -67,6 +70,14 @@ export const UserHomepage: UniversalComponent<UserHomepageType> = createUniversa
           {showReviews && (
             <DashboardTab $active={location.pathname === '/dashboard/reviews'}>
               <HrefLink href="/dashboard/reviews">Reviews</HrefLink>
+            </DashboardTab>
+          )}
+          <DashboardTab>
+            <a href={`/s/${slug}/profile`}>Manage account</a>
+          </DashboardTab>
+          {showAdmin && (
+            <DashboardTab>
+              <a href={`/s/${slug}/madoc/admin`}>Admin</a>
             </DashboardTab>
           )}
         </DashboardTabs>

--- a/services/madoc-ts/src/frontend/site/pages/user-homepage.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/user-homepage.tsx
@@ -1,3 +1,8 @@
+import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import { DashboardTab, DashboardTabs } from '../../shared/components/DashboardTabs';
+import { HrefLink } from '../../shared/utility/href-link';
+import { renderUniversalRoutes } from '../../shared/utility/server-utils';
 import { UniversalComponent } from '../../types';
 import { createUniversalComponent } from '../../shared/utility/create-universal-component';
 import { useStaticData } from '../../shared/hooks/use-data';
@@ -13,6 +18,8 @@ import { ReviewerTasks } from '../features/ReviewerTasks';
 import { UserGreeting } from '../features/UserGreeting';
 import { UserProjects } from '../features/UserProjects';
 import { UserStatistics } from '../features/UserStatistics';
+import { useRelativeLinks } from '../hooks/use-relative-links';
+import { useUserHomepage } from '../hooks/use-user-homepage';
 
 type UserHomepageType = {
   query: {};
@@ -31,8 +38,11 @@ type UserHomepageType = {
 };
 
 export const UserHomepage: UniversalComponent<UserHomepageType> = createUniversalComponent<UserHomepageType>(
-  () => {
+  ({ route }) => {
     const { data, error } = useStaticData(UserHomepage, {}, { retry: false });
+    const location = useLocation();
+
+    const showReviews = data && isReviewer(data.userDetails);
 
     if (error) {
       return <a href="/login">Please login</a>;
@@ -47,15 +57,21 @@ export const UserHomepage: UniversalComponent<UserHomepageType> = createUniversa
       <div>
         <UserGreeting />
 
-        <DashboardNavigation />
+        <DashboardTabs>
+          <DashboardTab $active={location.pathname === '/'}>
+            <HrefLink href="/">Overview</HrefLink>
+          </DashboardTab>
+          <DashboardTab $active={location.pathname === '/dashboard/contributions'}>
+            <HrefLink href="/dashboard/contributions">Contributions</HrefLink>
+          </DashboardTab>
+          {showReviews && (
+            <DashboardTab $active={location.pathname === '/dashboard/reviews'}>
+              <HrefLink href="/dashboard/reviews">Reviews</HrefLink>
+            </DashboardTab>
+          )}
+        </DashboardTabs>
 
-        <UserStatistics />
-
-        <ReviewerTasks />
-
-        <ContributorTasks />
-
-        <UserProjects />
+        {renderUniversalRoutes(route.routes)}
       </div>
     );
   },

--- a/services/madoc-ts/src/frontend/site/routes.ts
+++ b/services/madoc-ts/src/frontend/site/routes.ts
@@ -318,8 +318,29 @@ export function createRoutes(components: RouteComponents): UniversalRoute[] {
     },
     {
       path: '/',
-      exact: true,
       component: components.UserHomepage,
+      routes: [
+        {
+          path: '/',
+          exact: true,
+          component: components.UserDashboard,
+        },
+        {
+          path: '/dashboard/contributions',
+          exact: true,
+          component: components.UserContributions,
+        },
+        {
+          path: '/dashboard/reviews',
+          exact: true,
+          component: components.UserReviews,
+        },
+        {
+          path: '/',
+          // Fallback here.
+          component: components.UserDashboard,
+        },
+      ],
     },
   ];
 

--- a/services/madoc-ts/src/frontend/site/routes.ts
+++ b/services/madoc-ts/src/frontend/site/routes.ts
@@ -317,11 +317,11 @@ export function createRoutes(components: RouteComponents): UniversalRoute[] {
       component: components.Search,
     },
     {
-      path: '/',
+      path: '/dashboard',
       component: components.UserHomepage,
       routes: [
         {
-          path: '/',
+          path: '/dashboard',
           exact: true,
           component: components.UserDashboard,
         },
@@ -336,11 +336,16 @@ export function createRoutes(components: RouteComponents): UniversalRoute[] {
           component: components.UserReviews,
         },
         {
-          path: '/',
+          path: '/dashboard',
           // Fallback here.
           component: components.UserDashboard,
         },
       ],
+    },
+    {
+      path: '/',
+      // Fallback here.
+      component: components.Homepage,
     },
   ];
 

--- a/services/madoc-ts/src/middleware/omeka-page.ts
+++ b/services/madoc-ts/src/middleware/omeka-page.ts
@@ -45,12 +45,12 @@ export const omekaPage: RouteMiddleware<{ slug: string }> = async (context, next
     if (context.omekaPage) {
       // Return the response wrapped in Omeka.
       context.response.body = `
-        ${header}
+        ${context.omekaMinimal ? '' : header}
         ${(context.omekaMessages || []).map(
           ({ type, message }) => `<ul class="messages messages--body"><li class="${type}">${message}</li></ul>`
         )}
         ${context.omekaPage}
-        ${footer}
+        ${context.omekaMinimal ? '' : footer}
       `;
     }
   }

--- a/services/madoc-ts/src/routes/admin/frontend.ts
+++ b/services/madoc-ts/src/routes/admin/frontend.ts
@@ -22,6 +22,14 @@ export const adminFrontend: RouteMiddleware = context => {
       jwt: token,
       basename: `/s/${context.params.slug}/madoc/admin`,
       i18next: context.i18next.cloneInstance({ initImmediate: false }),
+      site: context.omeka.getSiteIdBySlug(context.params.slug),
+      user:
+        context.state.jwt && context.state.jwt.user && context.state.jwt.user.id
+          ? {
+              name: context.state.jwt.user.name,
+              id: context.state.jwt.user.id,
+            }
+          : undefined,
     });
 
     if (result.type === 'redirect') {
@@ -44,7 +52,8 @@ export const adminFrontend: RouteMiddleware = context => {
 
 export const siteFrontend: RouteMiddleware = context => {
   const bundle = context.routes.url('assets-bundles', { slug: context.params.slug, bundleId: 'site' });
-  context.omekaMinimal = false;
+  context.omekaMinimal = true;
+
   context.omekaPage = async token => {
     const result = await renderSite({
       url: context.req.url || '',
@@ -52,6 +61,14 @@ export const siteFrontend: RouteMiddleware = context => {
       basename: `/s/${context.params.slug}/madoc`,
       i18next: context.i18next.cloneInstance({ initImmediate: false }),
       siteSlug: context.params.slug,
+      site: context.omeka.getSiteIdBySlug(context.params.slug),
+      user:
+        context.state.jwt && context.state.jwt.user && context.state.jwt.user.id
+          ? {
+              name: context.state.jwt.user.name,
+              id: context.state.jwt.user.id,
+            }
+          : undefined,
     });
 
     if (result.type === 'redirect') {

--- a/services/madoc-ts/stories/admin.stories.tsx
+++ b/services/madoc-ts/stories/admin.stories.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { GlobalHeader } from '../src/frontend/shared/atoms/GlobalHeader';
 import { WidePage } from '../src/frontend/shared/atoms/WidePage';
 import { LightNavigation, LightNavigationItem } from '../src/frontend/shared/atoms/LightNavigation';
+import { SiteProvider } from '../src/frontend/shared/hooks/use-site';
 
 export default { title: 'Admin' };
 
@@ -25,71 +26,75 @@ export const adminHeader = () => (
 
 export const adminHeaderWithBreadcrumbsAndMenu = () => (
   <MemoryRouter>
-    <GlobalHeader
-      title={'Default site'}
-      username={'Some user'}
-      links={[
-        { label: 'Dashboard', link: '#' },
-        { label: 'View site', link: '#' },
-        { label: 'Account', link: '#' },
-        { label: 'Logout', link: '#' },
-      ]}
-    />
-    <AdminHeader
-      title="My awesome project"
-      breadcrumbs={[
-        { label: 'site dashboard', link: '#' },
-        { label: 'projects', link: '#' },
-        { label: 'My project', link: '#', active: true },
-      ]}
-      menu={[
-        { label: 'Overview', link: '#' },
-        { label: 'Basic details', link: '#' },
-        { label: 'Capture model', link: '#', active: true },
-        { label: 'Content', link: '#' },
-        { label: 'Access control', link: '#' },
-        { label: 'Export', link: '#' },
-      ]}
-    />
-    <WidePage>
-      <p>Test some content on this page.</p>
-    </WidePage>
+    <SiteProvider value={{ site: { slug: '#', id: 1 } }}>
+      <GlobalHeader
+        title={'Default site'}
+        username={'Some user'}
+        links={[
+          { label: 'Dashboard', link: '#' },
+          { label: 'View site', link: '#' },
+          { label: 'Account', link: '#' },
+          { label: 'Logout', link: '#' },
+        ]}
+      />
+      <AdminHeader
+        title="My awesome project"
+        breadcrumbs={[
+          { label: 'site dashboard', link: '#' },
+          { label: 'projects', link: '#' },
+          { label: 'My project', link: '#', active: true },
+        ]}
+        menu={[
+          { label: 'Overview', link: '#' },
+          { label: 'Basic details', link: '#' },
+          { label: 'Capture model', link: '#', active: true },
+          { label: 'Content', link: '#' },
+          { label: 'Access control', link: '#' },
+          { label: 'Export', link: '#' },
+        ]}
+      />
+      <WidePage>
+        <p>Test some content on this page.</p>
+      </WidePage>
+    </SiteProvider>
   </MemoryRouter>
 );
 
 export const adminHeaderWithBreadcrumbsAndMenuAndSearch = () => (
   <MemoryRouter>
-    <GlobalHeader
-      title={'Default site'}
-      username={'Some user'}
-      links={[
-        { label: 'Dashboard', link: '#' },
-        { label: 'View site', link: '#' },
-        { label: 'Account', link: '#' },
-        { label: 'Logout', link: '#' },
-      ]}
-    />
-    <AdminHeader
-      title="My awesome project"
-      breadcrumbs={[
-        { label: 'site dashboard', link: '#' },
-        { label: 'projects', link: '#' },
-        { label: 'My project', link: '#', active: true },
-      ]}
-      menu={[
-        { label: 'Overview', link: '#' },
-        { label: 'Basic details', link: '#' },
-        { label: 'Capture model', link: '#', active: true },
-        { label: 'Content', link: '#' },
-        { label: 'Access control', link: '#' },
-        { label: 'Export', link: '#' },
-      ]}
-      search={true}
-      searchFunction={val => [{ something: val }]}
-    />
-    <WidePage>
-      <p>Test some content on this page.</p>
-    </WidePage>
+    <SiteProvider value={{ site: { slug: '#', id: 1 } }}>
+      <GlobalHeader
+        title={'Default site'}
+        username={'Some user'}
+        links={[
+          { label: 'Dashboard', link: '#' },
+          { label: 'View site', link: '#' },
+          { label: 'Account', link: '#' },
+          { label: 'Logout', link: '#' },
+        ]}
+      />
+      <AdminHeader
+        title="My awesome project"
+        breadcrumbs={[
+          { label: 'site dashboard', link: '#' },
+          { label: 'projects', link: '#' },
+          { label: 'My project', link: '#', active: true },
+        ]}
+        menu={[
+          { label: 'Overview', link: '#' },
+          { label: 'Basic details', link: '#' },
+          { label: 'Capture model', link: '#', active: true },
+          { label: 'Content', link: '#' },
+          { label: 'Access control', link: '#' },
+          { label: 'Export', link: '#' },
+        ]}
+        search={true}
+        searchFunction={val => [{ something: val }]}
+      />
+      <WidePage>
+        <p>Test some content on this page.</p>
+      </WidePage>
+    </SiteProvider>
   </MemoryRouter>
 );
 

--- a/services/madoc-ts/stories/atoms.stories.tsx
+++ b/services/madoc-ts/stories/atoms.stories.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { SearchBox } from '../src/frontend/shared/atoms/SearchBox';
 import { Dropdown } from '@capture-models/editor';
 import { StandardButton } from '../src/frontend/shared/atoms/StandardButton';
+import { SiteProvider } from '../src/frontend/shared/hooks/use-site';
 
 export default { title: 'Atoms' };
 
@@ -28,13 +29,15 @@ export const buttons = () => (
 
 export const breadcrumbs = () => (
   <MemoryRouter>
-    <Breadcrumbs
-      items={[
-        { label: 'site dashboard', link: '#' },
-        { label: 'projects', link: '#' },
-        { label: 'My project', link: '#', active: true },
-      ]}
-    />
+    <SiteProvider value={{ site: { slug: '#', id: 1 } }}>
+      <Breadcrumbs
+        items={[
+          { label: 'site dashboard', link: '#' },
+          { label: 'projects', link: '#' },
+          { label: 'My project', link: '#', active: true },
+        ]}
+      />
+    </SiteProvider>
   </MemoryRouter>
 );
 

--- a/services/madoc-ts/stories/tabpanel.stories.tsx
+++ b/services/madoc-ts/stories/tabpanel.stories.tsx
@@ -1,10 +1,10 @@
-import React, {useState} from 'react';
+import * as React from 'react';
 import { TabPanel } from '../src/frontend/shared/components/TabPanel';
 
 export default { title: 'Tab Panel' };
 
-export const tabPanel = () => {
-  const [selected, setSelected] = useState(0);
+export const Tab_Panel = () => {
+  const [selected, setSelected] = React.useState(0);
   return (
     <TabPanel
       menu={[
@@ -15,6 +15,4 @@ export const tabPanel = () => {
       selected={selected}
     />
   );
-  }
-
-
+};

--- a/services/madoc-ts/stories/user-dashboard.stories.tsx
+++ b/services/madoc-ts/stories/user-dashboard.stories.tsx
@@ -7,7 +7,7 @@ import { Heading1 } from '../src/frontend/shared/atoms/Heading1';
 import { Heading3 } from '../src/frontend/shared/atoms/Heading3';
 import { DashboardTabs, DashboardTab } from '../src/frontend/shared/components/DashboardTabs';
 
-export const StorybookPaddedBox = styled.div`
+const StorybookPaddedBox = styled.div`
   max-width: 1200px;
   margin: 0 auto;
   padding: 1em;

--- a/services/madoc-ts/stories/user-homepage.stories.tsx
+++ b/services/madoc-ts/stories/user-homepage.stories.tsx
@@ -16,7 +16,7 @@ import { TableContainer, TableRow, TableRowLabel } from '../src/frontend/shared/
 import { Status } from '../src/frontend/shared/atoms/Status';
 import { GridContainer, HalfGird } from '../src/frontend/shared/atoms/Grid';
 
-export const StorybookPaddedBox = styled.div`
+const StorybookPaddedBox = styled.div`
   max-width: 1200px;
   margin: 0 auto;
   padding: 1em;

--- a/services/madoc/packages/madoc-crowd-sourcing-theme/view/layout/layout.phtml
+++ b/services/madoc/packages/madoc-crowd-sourcing-theme/view/layout/layout.phtml
@@ -27,14 +27,14 @@ endif;
 <header class="site-header">
     <div class="site-details">
         <?php if ($this->themeSetting('logo')): ?>
-            <a href="<?php echo $site->url(); ?>" class="site-title"><img
+            <a href="<?php echo $site->url(); ?>/madoc" class="site-title"><img
                         src="<?php echo $this->themeSettingAssetUrl('logo'); ?>"
                         title="<?php echo $this->translate('Logo') ?>"></a>
             <?php if ($this->themeSetting('show_title_and_logo')): ?>
                 <p class="site-name"><?php echo $site->title(); ?></p>
             <?php endif; ?>
         <?php else: ?>
-            <a href="<?php echo $site->url(); ?>" class="site-title"><?php echo $this->pageTitle($site->title()); ?></a>
+            <a href="<?php echo $site->url(); ?>/madoc" class="site-title"><?php echo $this->pageTitle($site->title()); ?></a>
         <?php endif; ?>
     </div>
     <div id="search">
@@ -57,16 +57,6 @@ endif;
 <main id="content" role="main">
     <?php print $this->content; ?>
 </main>
-<footer>
-
-    <div class="footer-inner">
-        <?php if ($footerContent = $this->themeSetting('footer')): ?>
-            <?php echo $footerContent; ?>
-        <?php else: ?>
-            <?php echo $this->translate('Powered by Madoc Platform running on Omeka S'); ?>
-        <?php endif; ?>
-    </div>
-</footer>
 <?php echo $this->headScript(); ?>
 </body>
 </html>

--- a/services/madoc/packages/madoc-crowd-sourcing-theme/view/omeka/site/page/show.phtml
+++ b/services/madoc/packages/madoc-crowd-sourcing-theme/view/omeka/site/page/show.phtml
@@ -23,14 +23,7 @@ if ($activePage):
 
 <?php $this->trigger('view.show.before'); ?>
 <div class="blocks">
-    <?php $content = trim($this->content); ?>
-    <?php if (!$content): ?>
-        <a href="/admin/site/s/<?php print $site->slug(); ?>/page/<?php print $page->slug(); ?>" style="display: block;text-align: center">
-            <img src="<?php echo $this->assetUrl('hello-madoc.svg'); ?>" alt="<?php print $this->translate('Login and add some content'); ?>" />
-        </a>
-    <?php else: ?>
-        <?php echo $content; ?>
-    <?php endif; ?>
+  <a href="/s/<?php print $site->slug(); ?>/madoc">Proceed to madoc</a>
 </div>
 <?php $this->trigger('view.show.after'); ?>
 <?php if ($showPagePagination): ?>


### PR DESCRIPTION
Main changes:
- Split the user dashboard into tabs
- Changed link in the top right to take you to Madoc admin
- Move Omeka admin link to Madoc admin homepage
- Added static homepage with temporary links
- Added static navigation elements - for now

Header changes:
![madocchanges](https://user-images.githubusercontent.com/8266711/107555497-25b5b600-6bcf-11eb-9357-5c238743b424.jpg)

Dashboard changes:
![Screenshot 2021-02-10 at 18 38 42](https://user-images.githubusercontent.com/8266711/107555635-4f6edd00-6bcf-11eb-9196-cfea4ef6fd7a.png)

