### PR TITLE
Prevent collections being indexed in search

### DIFF
--- a/services/madoc-ts/src/database/queries/get-collection-snippets.ts
+++ b/services/madoc-ts/src/database/queries/get-collection-snippets.ts
@@ -79,6 +79,7 @@ export function getSingleCollection({
 
       where single_collection.site_id = ${siteId}
         and single_collection.resource_id = ${collectionId}
+        and single_collection.resource_type = 'collection'
       ${
         type
           ? type === 'collection'

--- a/services/madoc-ts/src/database/queries/get-manifest-snippets.ts
+++ b/services/madoc-ts/src/database/queries/get-manifest-snippets.ts
@@ -51,6 +51,8 @@ export function getSingleManifest({
                          on manifest_count.resource_id = ${manifestId} and manifest_count.site_id = ${siteId}
       where manifest.resource_id = ${manifestId}
         and manifest.site_id = ${siteId}
+        and manifest.resource_type = 'manifest' 
+        and canvas_resources.type = 'canvas'
       order by canvas_links.item_index
       limit ${perPage}
       offset ${offset}


### PR DESCRIPTION
Or more broadly, prevent collections being requested at manifest endpoints. Also makes sure no invalid types can be returned in a manifest (only canvases)