### PR TITLE
MUYA-148 Activity streams

### DIFF
--- a/services/madoc-ts/migrations/2021-05-25T14-24.change-discovery.sql
+++ b/services/madoc-ts/migrations/2021-05-25T14-24.change-discovery.sql
@@ -1,0 +1,26 @@
+--change-discovery (up)
+create table change_discovery_activity
+(
+    activity_id serial not null,
+    activity_type text not null,
+    primary_stream text not null,
+    secondary_stream text,
+    object_id text not null,
+    object_type text not null,
+    object_canonical_id text not null,
+    end_time timestamp default CURRENT_TIMESTAMP,
+    start_time timestamp,
+    site_id int not null,
+    properties json
+);
+
+create unique index change_discovery_activity_activity_id_uindex
+    on change_discovery_activity (activity_id);
+
+create index change_discovery_activity_sort_index
+    on change_discovery_activity (primary_stream, secondary_stream, end_time, site_id);
+
+alter table change_discovery_activity
+    add constraint change_discovery_activity_pk
+        primary key (activity_id);
+

--- a/services/madoc-ts/migrations/down/2021-05-25T14-24.change-discovery.sql
+++ b/services/madoc-ts/migrations/down/2021-05-25T14-24.change-discovery.sql
@@ -1,0 +1,2 @@
+--change-discovery (down)
+drop table if exists change_discovery_activity cascade;

--- a/services/madoc-ts/src/activity-streams/change-discovery-repository.ts
+++ b/services/madoc-ts/src/activity-streams/change-discovery-repository.ts
@@ -1,0 +1,108 @@
+import { sql } from 'slonik';
+import { BaseRepository } from '../repository/base-repository';
+import { SQL_EMPTY } from '../utility/postgres-tags';
+import { sqlDate } from '../utility/slonik-helpers';
+import { ActivityItemRow, ChangeDiscoveryActivity, ChangeDiscoveryActivityType } from './change-discovery-types';
+
+type StreamOptions = { primaryStream: string; secondaryStream?: string };
+
+export class ChangeDiscoveryRepository extends BaseRepository {
+  async getTotalItems({ primaryStream, secondaryStream }: StreamOptions, siteId: number) {
+    const { total_items } = await this.connection.one(sql<{ total_items: number }>`
+      select COUNT(*) as total_items from change_discovery_activity
+      where
+        primary_stream = ${primaryStream} and
+        site_id = ${siteId}
+        ${secondaryStream ? sql`and secondary_stream = ${secondaryStream}` : sql`and secondary_stream is null`}
+`);
+
+    return total_items;
+  }
+
+  async getActivity(
+    { primaryStream, secondaryStream }: StreamOptions,
+    paging: { page: number; perPage: number },
+    siteId: number
+  ) {
+    const offset = paging.perPage * paging.page;
+
+    const items = await this.connection.any(sql<ActivityItemRow>`
+        select * from change_discovery_activity
+        where
+            primary_stream = ${primaryStream} and
+            site_id = ${siteId}
+            ${secondaryStream ? sql`and secondary_stream = ${secondaryStream}` : sql`and secondary_stream is null`}
+        order by end_time
+        limit ${paging.perPage} offset ${offset}
+    `);
+
+    return items.map(item => this.mapActivity(item));
+  }
+
+  async resourceExists({ primaryStream, secondaryStream }: StreamOptions, canonicalId: string, siteId: number) {
+    // Find the latest Add, Create, Delete or Remove for this resource in this site.
+    const exists = await this.connection.maybeOne(sql<{ activity_type: string }>`
+      select activity_type from change_discovery_activity
+      where
+        activity_type = ANY (${sql.array(['Add', 'Create', 'Delete', 'Remove'], 'text')}) and
+        object_canonical_id = ${canonicalId} and
+        primary_stream = ${primaryStream} and
+        site_id = ${siteId}
+        ${secondaryStream ? sql`and secondary_stream = ${secondaryStream}` : SQL_EMPTY}
+      order by end_time desc
+      limit 1
+    `);
+
+    return exists ? exists.activity_type !== 'Delete' && exists.activity_type !== 'Remove' : false;
+  }
+
+  async addActivity(
+    action: ChangeDiscoveryActivityType,
+    { primaryStream, secondaryStream }: StreamOptions,
+    object: ChangeDiscoveryActivity['object'],
+    siteId: number
+  ) {
+    const { id, type, canonical, endTime, startTime, ...properties } = object;
+
+    const createdActivity = await this.connection.one(sql<ActivityItemRow>`
+        insert into change_discovery_activity (
+          activity_type,
+          primary_stream,
+          secondary_stream,
+          object_id,
+          object_type,
+          object_canonical_id,
+          start_time,
+          site_id,
+          properties
+        ) VALUES (
+          ${action},
+          ${primaryStream},
+          ${secondaryStream || null},
+          ${id},
+          ${type},
+          ${canonical || id},
+          ${startTime ? sqlDate(new Date(startTime)) : null},
+          ${siteId},
+          ${sql.json(properties as any)}
+        ) returning *
+    `);
+
+    return this.mapActivity(createdActivity);
+  }
+
+  mapActivity(row: ActivityItemRow): { id: number; type: string; object: ChangeDiscoveryActivity['object'] } {
+    return {
+      id: row.activity_id,
+      type: row.activity_type,
+      object: {
+        id: row.object_id,
+        type: row.object_type as any,
+        endTime: new Date(row.end_time).toISOString(),
+        startTime: row.start_time ? new Date(row.start_time).toISOString() : undefined,
+        canonical: row.object_canonical_id,
+        ...(row.properties || {}),
+      },
+    };
+  }
+}

--- a/services/madoc-ts/src/activity-streams/change-discovery-types.ts
+++ b/services/madoc-ts/src/activity-streams/change-discovery-types.ts
@@ -8,25 +8,55 @@ import { InternationalString, Manifest } from '@hyperion-framework/types';
  * - 3. Publish endpoints for tracking those changes.
  */
 
+export type ActivityItemRow = {
+  activity_id: number;
+  activity_type: string;
+  primary_stream: string;
+  secondary_string: string | null;
+  object_id: string;
+  object_type: string;
+  object_canonical_id: string;
+  start_time: number | null;
+  end_time: number;
+  site_id: number;
+  // A JSON field
+  properties: {
+    summary: string;
+    provider?: Manifest['provider'];
+    seeAlso?: ChangeDiscoverySeeAlso[];
+    actor?: ChangeDiscoveryActor;
+    target?: ChangeDiscoveryBaseObject;
+  };
+};
+
 export type ChangeDiscoveryActivity = {
   id: string;
-  type: ChangeDiscoveryActivityType;
-  object: ChangeDiscoveryObject;
-};
+} & (
+  | {
+      type: Exclude<ChangeDiscoveryActivityType, 'Move'>;
+      object: ChangeDiscoveryBaseObject;
+    }
+  | {
+      type: 'Move';
+      object: ChangeDiscoveryMoveObject;
+    }
+);
 
 export type ChangeDiscoveryBaseObject = {
   id: string;
   canonical?: string;
-  type: 'Collection' | 'Manifest'; // Technically also: Range, Canvas etc.
+  type: 'Collection' | 'Manifest' | 'Canvas'; // Technically also: Range, Canvas etc.
   seeAlso?: ChangeDiscoverySeeAlso[];
-  provider?: Manifest;
+  provider?: Manifest['provider'];
   endTime?: string; // xsd:dateTime
   startTime?: string; // xsd:dateTime
   summary?: string;
-  actor?: {
-    id: string;
-    type: 'Person' | 'Application' | 'Organization';
-  };
+  actor?: ChangeDiscoveryActor;
+};
+
+type ChangeDiscoveryActor = {
+  id: string;
+  type: 'Person' | 'Application' | 'Organization';
 };
 
 export type ChangeDiscoveryGenesisRequest = {
@@ -38,7 +68,7 @@ export type ChangeDiscoveryGenesisResponse = {
   ids: string[];
 };
 
-export type ChangeDiscoveryObject = ChangeDiscoveryBaseObject & {
+export type ChangeDiscoveryMoveObject = ChangeDiscoveryBaseObject & {
   target: ChangeDiscoveryBaseObject;
 };
 

--- a/services/madoc-ts/src/activity-streams/change-discovery-types.ts
+++ b/services/madoc-ts/src/activity-streams/change-discovery-types.ts
@@ -29,8 +29,21 @@ export type ActivityItemRow = {
   };
 };
 
+export type ChangeDiscoveryActivityRequest = {
+  startTime?: string; // xsd:dateTime
+  summary?: string;
+  actor?: ChangeDiscoveryActor;
+  target?: ChangeDiscoveryBaseObject;
+  object: ChangeDiscoveryBaseObject;
+};
+
 export type ChangeDiscoveryActivity = {
   id: string;
+  endTime: string; // xsd:dateTime
+  startTime?: string; // xsd:dateTime
+  summary?: string;
+  actor?: ChangeDiscoveryActor;
+  target?: ChangeDiscoveryBaseObject;
 } & (
   | {
       type: Exclude<ChangeDiscoveryActivityType, 'Move'>;
@@ -38,7 +51,8 @@ export type ChangeDiscoveryActivity = {
     }
   | {
       type: 'Move';
-      object: ChangeDiscoveryMoveObject;
+      object: ChangeDiscoveryBaseObject;
+      target: ChangeDiscoveryBaseObject;
     }
 );
 
@@ -48,10 +62,6 @@ export type ChangeDiscoveryBaseObject = {
   type: 'Collection' | 'Manifest' | 'Canvas'; // Technically also: Range, Canvas etc.
   seeAlso?: ChangeDiscoverySeeAlso[];
   provider?: Manifest['provider'];
-  endTime?: string; // xsd:dateTime
-  startTime?: string; // xsd:dateTime
-  summary?: string;
-  actor?: ChangeDiscoveryActor;
 };
 
 type ChangeDiscoveryActor = {
@@ -66,10 +76,6 @@ export type ChangeDiscoveryGenesisRequest = {
 export type ChangeDiscoveryGenesisResponse = {
   prefix: string;
   ids: string[];
-};
-
-export type ChangeDiscoveryMoveObject = ChangeDiscoveryBaseObject & {
-  target: ChangeDiscoveryBaseObject;
 };
 
 export type ChangeDiscoveryImplementationState = {

--- a/services/madoc-ts/src/activity-streams/router.ts
+++ b/services/madoc-ts/src/activity-streams/router.ts
@@ -1,0 +1,37 @@
+import { RouteWithParams, TypedRouter } from '../utility/typed-router';
+import { getActivityStream } from './routes/get-activity-stream';
+import { getActivityStreamPage } from './routes/get-activity-stream-page';
+import { postActivity } from './routes/post-activity';
+
+// create: 'Create',
+//   update: 'Update',
+//   delete: 'Delete',
+//   move: 'Move',
+//   add: 'Add',
+//   remove: 'Remove',
+export const router: Record<keyof any, RouteWithParams<any>> = {
+  'activity-get-primary-stream': [TypedRouter.GET, '/api/madoc/activity/:primaryStream/changes', getActivityStream],
+  'activity-get-primary-stream-page': [
+    TypedRouter.GET,
+    '/api/madoc/activity/:primaryStream/page/:page',
+    getActivityStreamPage,
+  ],
+
+  'activity-get-secondary-stream': [
+    TypedRouter.GET,
+    '/api/madoc/activity/:primaryStream/stream/:secondaryStream/changes',
+    getActivityStream,
+  ],
+  'activity-get-secondary-stream-page': [
+    TypedRouter.GET,
+    '/api/madoc/activity/:primaryStream/stream/:secondaryStream/page/:page',
+    getActivityStreamPage,
+  ],
+
+  'activity-item-create-primary': [TypedRouter.POST, '/api/madoc/activity/:primaryStream/action/:action', postActivity],
+  'activity-item-create-secondary': [
+    TypedRouter.POST,
+    '/api/madoc/activity/:primaryStream/stream/:secondaryStream/action/:action',
+    postActivity,
+  ],
+};

--- a/services/madoc-ts/src/activity-streams/routes/get-activity-stream-page.ts
+++ b/services/madoc-ts/src/activity-streams/routes/get-activity-stream-page.ts
@@ -1,0 +1,53 @@
+import { gatewayHost } from '../../gateway/api.server';
+import { RouteMiddleware } from '../../types/route-middleware';
+import { NotFound } from '../../utility/errors/not-found';
+import { optionalUserWithScope } from '../../utility/user-with-scope';
+
+export const getActivityStreamPage: RouteMiddleware<{
+  primaryStream: string;
+  secondaryStream?: string;
+  page: string;
+}> = async context => {
+  // At least for now.
+  const { siteId } = optionalUserWithScope(context, ['site.admin']);
+  const { primaryStream, secondaryStream } = context.params;
+  const perPage = 100;
+  const page = Number(context.params.page);
+  const [totalItems, orderedItems] = await Promise.all([
+    context.changeDiscovery.getTotalItems({ primaryStream, secondaryStream }, siteId),
+    context.changeDiscovery.getActivity({ primaryStream, secondaryStream }, { page, perPage }, siteId),
+  ]);
+
+  const baseUrl = `${gatewayHost}/api/madoc/activity/${primaryStream}${
+    secondaryStream ? '/stream/' + secondaryStream : ''
+  }`;
+  const hasNextPage = totalItems > page * perPage;
+  const hasPrevPage = page > 0;
+
+  if (Number.isNaN(page)) {
+    throw new NotFound();
+  }
+
+  context.response.body = {
+    '@context': 'http://iiif.io/api/discovery/1/context.json',
+    id: `${baseUrl}/page/${page}`,
+    type: 'OrderedCollectionPage',
+    partOf: {
+      id: 'https://example.org/activity/all-changes',
+      type: 'OrderedCollection',
+    },
+    prev: hasPrevPage
+      ? {
+          id: `${baseUrl}/page/${page - 1}`,
+          type: 'OrderedCollectionPage',
+        }
+      : undefined,
+    next: hasNextPage
+      ? {
+          id: `${baseUrl}/page/${page + 1}`,
+          type: 'OrderedCollectionPage',
+        }
+      : undefined,
+    orderedItems: orderedItems,
+  };
+};

--- a/services/madoc-ts/src/activity-streams/routes/get-activity-stream-page.ts
+++ b/services/madoc-ts/src/activity-streams/routes/get-activity-stream-page.ts
@@ -48,6 +48,9 @@ export const getActivityStreamPage: RouteMiddleware<{
           type: 'OrderedCollectionPage',
         }
       : undefined,
-    orderedItems: orderedItems,
+    orderedItems: orderedItems.map(item => {
+      item.id = `${baseUrl}/activity/${item.id}`;
+      return item;
+    }),
   };
 };

--- a/services/madoc-ts/src/activity-streams/routes/get-activity-stream.ts
+++ b/services/madoc-ts/src/activity-streams/routes/get-activity-stream.ts
@@ -1,0 +1,45 @@
+import { RouteMiddleware } from '../../types/route-middleware';
+import { optionalUserWithScope } from '../../utility/user-with-scope';
+import { gatewayHost } from '../../gateway/api.server';
+
+export const getActivityStream: RouteMiddleware<{
+  primaryStream: string;
+  secondaryStream?: string;
+}> = async context => {
+  const { siteId } = optionalUserWithScope(context, ['site.admin']);
+  const { primaryStream, secondaryStream } = context.params;
+
+  const perPage = 100;
+  const totalItems = await context.changeDiscovery.getTotalItems({ primaryStream, secondaryStream }, siteId);
+
+  const firstPage = 0;
+  const lastPage = Math.ceil(totalItems / perPage);
+  const baseUrl = `${gatewayHost}/api/madoc/activity/${primaryStream}${
+    secondaryStream ? '/stream/' + secondaryStream : ''
+  }`;
+
+  context.response.status = 200;
+  context.response.body = {
+    '@context': 'http://iiif.io/api/discovery/1/context.json',
+    id: `${baseUrl}/changes`,
+    type: 'OrderedCollection',
+    totalItems: totalItems,
+    rights: 'http://creativecommons.org/licenses/by/4.0/',
+    partOf: secondaryStream
+      ? [
+          {
+            id: `${gatewayHost}/api/madoc/activity/${primaryStream}`,
+            type: 'OrderedCollection',
+          },
+        ]
+      : undefined,
+    first: {
+      id: `${baseUrl}/page/${firstPage}`,
+      type: 'OrderedCollectionPage',
+    },
+    last: {
+      id: `${baseUrl}/page/${lastPage}`,
+      type: 'OrderedCollectionPage',
+    },
+  };
+};

--- a/services/madoc-ts/src/activity-streams/routes/post-activity.ts
+++ b/services/madoc-ts/src/activity-streams/routes/post-activity.ts
@@ -1,0 +1,156 @@
+import { RouteMiddleware } from '../../types/route-middleware';
+import { NotFound } from '../../utility/errors/not-found';
+import { RequestError } from '../../utility/errors/request-error';
+import { optionalUserWithScope } from '../../utility/user-with-scope';
+import {
+  ChangeDiscoveryActivityType,
+  ChangeDiscoveryBaseObject,
+  ChangeDiscoveryMoveObject,
+} from '../change-discovery-types';
+
+const actionMap: { [key: string]: ChangeDiscoveryActivityType } = {
+  create: 'Create',
+  update: 'Update',
+  delete: 'Delete',
+  move: 'Move',
+  add: 'Add',
+  remove: 'Remove',
+};
+
+export const postActivity: RouteMiddleware<
+  {
+    primaryStream: string;
+    secondaryStream?: string;
+    action: string;
+  },
+  {
+    object: ChangeDiscoveryBaseObject | ChangeDiscoveryMoveObject;
+    options?: {
+      dispatchToSecondaryStreams?: boolean;
+      preventAddToPrimaryStream?: boolean;
+      preventUpdateToPrimaryStream?: boolean;
+    };
+  }
+> = async context => {
+  const { siteId } = optionalUserWithScope(context, ['site.admin']);
+  const { action: unmappedAction, primaryStream, secondaryStream } = context.params;
+  const action = actionMap[unmappedAction];
+  const {
+    object,
+    options: { dispatchToSecondaryStreams, preventAddToPrimaryStream, preventUpdateToPrimaryStream } = {},
+  } = context.requestBody;
+
+  // Basic validation.
+  if (!action) {
+    throw new NotFound();
+  }
+  if (!object || !object.id || !object.type) {
+    throw new RequestError('Objects must have a id and type fields.');
+  }
+  const canonicalId = object.canonical || object.id;
+
+  if (secondaryStream && !preventAddToPrimaryStream) {
+    const existsInPrimaryStream = await context.changeDiscovery.resourceExists({ primaryStream }, canonicalId, siteId);
+    if (!existsInPrimaryStream && action !== 'Remove' && action !== 'Delete') {
+      await context.changeDiscovery.addActivity(
+        'Add',
+        {
+          primaryStream,
+        },
+        {
+          id: object.id,
+          type: object.type,
+          canonical: object.canonical,
+          summary: `Automatically created activity from secondary stream: ${secondaryStream}`,
+        },
+        siteId
+      );
+    }
+  }
+
+  const doesObjectExist = await context.changeDiscovery.resourceExists(
+    { primaryStream, secondaryStream },
+    canonicalId,
+    siteId
+  );
+  if (action !== 'Move' && action !== 'Remove' && action !== 'Delete' && !doesObjectExist) {
+    await context.changeDiscovery.addActivity(
+      'Add',
+      {
+        primaryStream,
+        secondaryStream,
+      },
+      {
+        id: object.id,
+        type: object.type,
+        canonical: object.canonical,
+        summary: `Automatically created before action: ${action}`,
+      },
+      siteId
+    );
+
+    // Artificial 50ms delay to prevent any chance of timestamps being identical.
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  if (!doesObjectExist && (action === 'Remove' || action === 'Delete')) {
+    // Do nothing.
+    context.response.status = 200;
+    return;
+  }
+
+  if (action === 'Move' && !doesObjectExist) {
+    // Should we handle this differently?
+  }
+
+  if (secondaryStream) {
+    // Add event into secondary stream
+    const activity = await context.changeDiscovery.addActivity(
+      action,
+      {
+        primaryStream,
+        secondaryStream,
+      },
+      object,
+      siteId
+    );
+
+    context.response.status = 201;
+    context.response.body = activity;
+
+    if (action === 'Update' && !preventUpdateToPrimaryStream) {
+      // Add to primary stream
+      await context.changeDiscovery.addActivity(
+        action,
+        {
+          primaryStream,
+        },
+        {
+          ...object,
+          summary: `(source: ${secondaryStream}): ${object.summary || `No summary provided for ${action} action`}`,
+        },
+        siteId
+      );
+    }
+  } else {
+    // Add event into primary stream
+    const activity = await context.changeDiscovery.addActivity(
+      action,
+      {
+        primaryStream,
+      },
+      object,
+      siteId
+    );
+
+    context.response.status = 201;
+    context.response.body = activity;
+
+    if (dispatchToSecondaryStreams) {
+      // @todo future feature.
+      // Add to all secondary streams.
+      // - Check if we need to upsert Add
+      // - Perform update.
+    }
+  }
+};

--- a/services/madoc-ts/src/frontend/admin/server.tsx
+++ b/services/madoc-ts/src/frontend/admin/server.tsx
@@ -11,7 +11,6 @@ import AdminApp from './index';
 import { queryConfig } from './query-config';
 import { routes } from './routes';
 import { createServerRenderer } from '../shared/utility/create-server-renderer';
-
-const apiGateway = process.env.API_GATEWAY as string;
+import { apiGateway } from '../../gateway/api.server';
 
 export const render = createServerRenderer(AdminApp as any, routes, apiGateway, queryConfig);

--- a/services/madoc-ts/src/frontend/site/server.ts
+++ b/services/madoc-ts/src/frontend/site/server.ts
@@ -11,7 +11,6 @@ import SiteApp from './index';
 import { createRoutes } from './routes';
 import * as components from './components';
 import { createServerRenderer } from '../shared/utility/create-server-renderer';
-
-const apiGateway = process.env.API_GATEWAY as string;
+import { apiGateway } from '../../gateway/api.server';
 
 export const render = createServerRenderer(SiteApp, createRoutes(components), apiGateway);

--- a/services/madoc-ts/src/gateway/api.server.ts
+++ b/services/madoc-ts/src/gateway/api.server.ts
@@ -1,7 +1,8 @@
 import { ApiClient } from './api';
 import { getServiceJwt } from './token';
 
-const apiGateway = process.env.API_GATEWAY as string;
+export const apiGateway = process.env.API_GATEWAY as string;
+export const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
 
 export const api = new ApiClient({
   gateway: apiGateway,

--- a/services/madoc-ts/src/middleware/postgres-connection.ts
+++ b/services/madoc-ts/src/middleware/postgres-connection.ts
@@ -1,5 +1,6 @@
 import { Middleware } from 'koa';
 import { DatabasePoolType } from 'slonik';
+import { ChangeDiscoveryRepository } from '../activity-streams/change-discovery-repository';
 import { MediaRepository } from '../repository/media-repository';
 import { PageBlocksRepository } from '../repository/page-blocks-repository';
 import { ThemeRepository } from '../repository/theme-repository';
@@ -12,6 +13,7 @@ export const postgresConnection = (pool: DatabasePoolType): Middleware => async 
     context.pageBlocks = new PageBlocksRepository(connection);
     context.media = new MediaRepository(connection);
     context.themes = new ThemeRepository(connection);
+    context.changeDiscovery = new ChangeDiscoveryRepository(connection);
 
     await next();
   });

--- a/services/madoc-ts/src/router.ts
+++ b/services/madoc-ts/src/router.ts
@@ -126,13 +126,13 @@ import { deleteLinking } from './routes/iiif/linking/delete-linking';
 import { updateLinking } from './routes/iiif/linking/update-linking';
 import { getLinking } from './routes/iiif/linking/get-linking';
 import { searchManifest } from './routes/iiif/manifests/search-manifest';
-import { exportManifest } from './routes/iiif/manifests/export-manifest';
 import { assignReview } from './routes/projects/assign-review';
 import { getProjectModel } from './routes/projects/get-project-model';
 import { siteCanvasModels } from './routes/site/site-canvas-models';
 import { siteCanvasTasks } from './routes/site/site-canvas-tasks';
 import { getProjectTask } from './routes/projects/get-project-task';
 import { assignRandomResource } from './routes/projects/assign-random-resource';
+import { router as activityStreamRoutes } from './activity-streams/router';
 
 export const router = new TypedRouter({
   // Normal route
@@ -388,6 +388,9 @@ export const router = new TypedRouter({
     '/s/:slug/madoc/api/projects/:projectSlug/export/manifest/:id/:version',
     buildManifest,
   ],
+
+  // Other routes.
+  ...activityStreamRoutes,
 
   // PAT
   'personal-access-token': [TypedRouter.POST, '/api/madoc/access-token', personalAccessToken],

--- a/services/madoc-ts/src/routes/iiif/manifests/build-manifest.ts
+++ b/services/madoc-ts/src/routes/iiif/manifests/build-manifest.ts
@@ -2,6 +2,7 @@ import { AnnotationPage } from '@hyperion-framework/types';
 import { Vault } from '@hyperion-framework/vault';
 import { sql } from 'slonik';
 import { deprecationGetItemsJson } from '../../../deprecations/01-local-source-canvas';
+import { gatewayHost } from '../../../gateway/api.server';
 import { RouteMiddleware } from '../../../types/route-middleware';
 import { IIIFBuilder } from '../../../utility/iiif-builder/iiif-builder';
 import { createMetadataReducer } from '../../../utility/iiif-metadata';
@@ -68,8 +69,6 @@ type IIIFExportRow = {
         metadata__source: null;
       }
   );
-
-const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
 
 export const buildManifest: RouteMiddleware<{
   slug: string;

--- a/services/madoc-ts/src/routes/iiif/manifests/export-manifest.ts
+++ b/services/madoc-ts/src/routes/iiif/manifests/export-manifest.ts
@@ -1,8 +1,7 @@
 import { RouteMiddleware } from '../../../types/route-middleware';
 import { sql } from 'slonik';
 import * as fs from 'fs';
-
-const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
+import { gatewayHost } from '../../../gateway/api.server';
 
 export const exportManifest: RouteMiddleware<{ id: string; slug: string }> = async context => {
   const manifestId = context.params.id;

--- a/services/madoc-ts/src/routes/iiif/manifests/search-manifest.ts
+++ b/services/madoc-ts/src/routes/iiif/manifests/search-manifest.ts
@@ -1,8 +1,7 @@
 import { RouteMiddleware } from '../../../types/route-middleware';
 import { sql } from 'slonik';
 import { SearchServiceSearchResponse } from '@hyperion-framework/types';
-
-const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
+import { gatewayHost } from '../../../gateway/api.server';
 
 export const searchManifest: RouteMiddleware<{ id: number }> = async context => {
   const { siteApi } = context.state;

--- a/services/madoc-ts/src/routes/site/site-published-models.ts
+++ b/services/madoc-ts/src/routes/site/site-published-models.ts
@@ -4,15 +4,13 @@ import { sql } from 'slonik';
 import { getProject } from '../../database/queries/project-queries';
 import { PARAGRAPHS_PROFILE } from '../../extensions/capture-models/Paragraphs/Paragraphs.helpers';
 import { RouteMiddleware } from '../../types/route-middleware';
-import { CaptureModelSnippet } from '../../types/schemas/capture-model-snippet';
 import { castBool } from '../../utility/cast-bool';
 import {
   captureModelFieldToOpenAnnotation,
   captureModelFieldToW3CAnnotation,
 } from '../../utility/model-annotation-helpers';
 import { parseProjectId } from '../../utility/parse-project-id';
-
-const gatewayHost = process.env.GATEWAY_HOST || 'http://localhost:8888';
+import { gatewayHost } from '../../gateway/api.server';
 
 export type SitePublishedModelsQuery = {
   format?:

--- a/services/madoc-ts/src/types/application-context.ts
+++ b/services/madoc-ts/src/types/application-context.ts
@@ -1,4 +1,5 @@
 import { i18n } from 'i18next';
+import { ChangeDiscoveryRepository } from '../activity-streams/change-discovery-repository';
 import { MediaRepository } from '../repository/media-repository';
 import { PageBlocksRepository } from '../repository/page-blocks-repository';
 import { ThemeRepository } from '../repository/theme-repository';
@@ -19,6 +20,7 @@ export interface ApplicationContext {
   pageBlocks: PageBlocksRepository;
   themes: ThemeRepository;
   media: MediaRepository;
+  changeDiscovery: ChangeDiscoveryRepository;
   omeka: OmekaApi;
   cron: CronJobs;
   ajv: Ajv;

--- a/services/madoc-ts/src/utility/postgres-tags.ts
+++ b/services/madoc-ts/src/utility/postgres-tags.ts
@@ -4,3 +4,4 @@ export const SQL_COMMA = sql`,`;
 export const SQL_EMPTY = sql``;
 export const SQL_INT_ARRAY = sql`int[]`;
 export const SQL_AND = sql` and `;
+export const SQL_NULL = sql`NULL`;

--- a/services/madoc-ts/src/utility/slonik-helpers.ts
+++ b/services/madoc-ts/src/utility/slonik-helpers.ts
@@ -50,8 +50,17 @@ export function upsert<T>(
              )}) do update
              set 
                 ${sql.join(
-                  keys.map(key => sql`${sql.identifier([key as string])} = ${sql.identifier(['excluded', key as string])}`),
+                  keys.map(
+                    key => sql`${sql.identifier([key as string])} = ${sql.identifier(['excluded', key as string])}`
+                  ),
                   sql`,`
                 )};
     `;
+}
+
+export function sqlDate(dateLike: Date) {
+  return sql`${dateLike
+    .toISOString()
+    .replace('T', ' ')
+    .replace('Z', '')}::date`;
 }


### PR DESCRIPTION
This PR contains the data model for managing generic activity streams. It provides a protocol for retrieving collections and pages as defined in the change discovery and a bespoke post endpoint for creating events.

Each stream can be sub-divided (or aggregated depending on how you look at it) into many streams.

### Primary streams
The top level streams are one-to-one with sites in Madoc. The identifier of the stream is the URL you choose to POST activity too. This allows Madoc, or any system, to have ownership of where streams are. Madoc will use this to publish activity streams for projects and being able to construct that URL with a project identifier alone. 

As per the spec, when you fetch a stream it will look like this:

```json
GET /api/madoc/activity/test-stream/changes

{
  "@context": "http://iiif.io/api/discovery/1/context.json",
  "id": "http://localhost:8888/api/madoc/activity/test-stream/changes",
  "type": "OrderedCollection",
  "totalItems": 2,
  "rights": "http://creativecommons.org/licenses/by/4.0/",
  "first": {
    "id": "http://localhost:8888/api/madoc/activity/test-stream/page/0",
    "type": "OrderedCollectionPage"
  },
  "last": {
    "id": "http://localhost:8888/api/madoc/activity/test-stream/page/1",
    "type": "OrderedCollectionPage"
  }
}
```

You can publish an event with a POST on the appropriate action endpoint.
```json
POST /api/madoc/activity/example-stream/action/update

{
  "object": {
    "id": "http://example.org/collections/2021-05-25T17:49:31+00:00",
    "type": "Manifest"
  },
    "summary": "Creating this manifest with a custom message"
}
```

There are also a handful of options, their meaning will become clearer. Defaults shown:
```json
POST /api/madoc/activity/example-stream/action/update

{
  "object": {
    "id": "http://example.org/collections/2021-05-25T17:49:31+00:00",
    "type": "Manifest"
  },
  "summary": "Creating this manifest with a custom message",
  "options": {
    "dispatchToSecondaryStreams": false,
    "preventAddToPrimaryStream": false,
    "preventUpdateToPrimaryStream": false
  }
}
```

If you publish an _"Update"_ but the item does not exist yet, an _"Add"_ will be created for you. Although probably best to add things before whenever possible.

Fetching the first page of the stream:
```json
GET /api/madoc/activity/example-stream/page/0

{
  "@context": "http://iiif.io/api/discovery/1/context.json",
  "id": "http://localhost:8888/api/madoc/activity/example-stream/page/0",
  "type": "OrderedCollectionPage",
  "partOf": {
    "id": "https://example.org/activity/all-changes",
    "type": "OrderedCollection"
  },
  "next": {
    "id": "http://localhost:8888/api/madoc/activity/example-stream/page/1",
    "type": "OrderedCollectionPage"
  },
  "orderedItems": [
    {
      "id": 29,
      "type": "Add",
      "object": {
        "id": "http://example.org/collections/2021-05-25T17:46:35+00:00",
        "type": "Manifest",
        "canonical": "http://example.org/collections/2021-05-25T17:46:35+00:00"
      },
      "summary": "Automatically created before action: Update",
      "endTime": "2021-05-25T17:46:35.479Z"
    },
    {
      "id": 30,
      "type": "Update",
      "object": {
        "id": "http://example.org/collections/2021-05-25T17:46:35+00:00",
        "type": "Manifest",
        "canonical": "http://example.org/collections/2021-05-25T17:46:35+00:00"
      },
      "endTime": "2021-05-25T17:46:35.541Z",
      "summary": "Creating this manifest with a custom message"
    }
  ]
}
```

### Secondary streams

Say for example I wanted a stream to track whenever a Manifest has completed being OCR'd. My stream might live at:
```
GET /api/madoc/activity/new-ocr/changes
```
Now if I was running a few projects and I wanted the new OCR just for that project, I could publish instead to secondary streams and have them aggregated into the one above.
```
GET /api/madoc/activity/test-stream/stream/my-ocr-project/changes
GET /api/madoc/activity/test-stream/stream/my-other-ocr-project/changes
```

Whenever you publish to a secondary stream, the primary will be updated. Summary field is used whenever updates are made automatically with a description. For example, if you made an `"Update"` and that particular item had not yet been added to the stream, the following 2 items would be added to the primary stream. (Note the summary)
```json
[
    {
      "id": 31,
      "type": "Add",
      "object": {
        "id": "http://example.org/collections/2021-05-25T17:56:29+00:00",
        "type": "Manifest",
        "canonical": "http://example.org/collections/2021-05-25T17:56:29+00:00"
      },
      "endTime": "2021-05-25T17:56:29.943Z",
      "summary": "Automatically created activity from secondary stream: test-project"
    },
    {
      "id": 34,
      "type": "Update",
      "object": {
        "id": "http://example.org/collections/2021-05-25T17:56:29+00:00",
        "type": "Manifest",
        "canonical": "http://example.org/collections/2021-05-25T17:56:29+00:00"
      },
      "endTime": "2021-05-25T17:56:30.038Z",
      "summary": "(source: test-project): Creating manifest in secondary stream"
    }
]
```

This simplified aggregation significantly, with the intentional limit of primary and secondary streams - no further nesting. When posting to a secondary stream you can choose if you want the primary stream updated. For example, if you were updating all of the secondary streams, you might only need the first to reflect the change in the primary (Duplicates are caught in the processing algo though).

A space has been left for the opposite interaction where posting an event to the primary stream can propagate that change down to  the secondary streams. Currently each stream has it's own distinct set of items, and this does result in duplication in the database. However, it does _avoid_ duplication in the streams themselves if you were to simply aggregate changes.

### Data model
This application for the most part does not care about which changes you make, aside from ensuring consistency and validity around create/add before delete/remove. Applications using this feature/endpoint will have ownership of creating and parsing the objects. ID / Type are all that are required, along with a valid action.

### Genesis / Refresh
The `Refresh` activity is not currently supported and we don't have a use-case currently where we need it.