### PR TITLE
MAD-770 - selectors + entity bugfixes

### DIFF
--- a/e2e/cypress/integration/crowdsourcing/04-transcriber-mode.ts
+++ b/e2e/cypress/integration/crowdsourcing/04-transcriber-mode.ts
@@ -68,6 +68,7 @@ describe('Empty site users', () => {
     // 1. Task is complete message.
     cy.contains('Task is complete!');
     cy.contains('Thank you. You finished this manifest. Go back to the project to find a new manifest to transcribe.');
+    cy.wait(1000);
 
     // 2. Manifest page says ready for review.
     cy.get('a').contains('00001').click();
@@ -116,6 +117,7 @@ describe('Empty site users', () => {
 
     // Completed the whole manifest.
     cy.contains('Thank you. You finished this manifest. Go back to the project to find a new manifest to transcribe.');
+    cy.wait(1000);
 
     // 2. Manifest page says ready for review.
     cy.get('a').contains('00002').click();
@@ -126,7 +128,7 @@ describe('Empty site users', () => {
     cy.get('[title="00002"]').should('not.exist');
   });
 
-  it.only('Transcriber submitting 1, marking one as unusable and then marking as too difficult', () => {
+  it('Transcriber submitting 1, marking one as unusable and then marking as too difficult', () => {
     cy.loadSite('transcriber-mode');
 
     // Transcriber.

--- a/e2e/cypress/integration/crowdsourcing/05-selectors.ts
+++ b/e2e/cypress/integration/crowdsourcing/05-selectors.ts
@@ -1,0 +1,171 @@
+/// <reference types="../../types" />
+describe('Empty site users', () => {
+  beforeEach(() => {
+    cy.loadSite('empty-site-users', true);
+  });
+
+  // "fields": [
+  //   [
+  //     "entity",
+  //     [
+  //       "test"
+  //     ]
+  //   ],
+  //   [
+  //     "entity-multiple",
+  //     [
+  //       "name"
+  //     ]
+  //   ],
+  //   "field-multiple",
+  //   "field"
+  // ]
+
+  it('Saving single field selector', () => {
+    cy.siteLogin('Transcriber');
+    cy.visit('/s/default/madoc/projects/project-with-selectors/manifests/2/c/4/model');
+
+    cy.server();
+    cy.intercept('POST', '/api/crowdsourcing/model/*/revision').as('revision');
+
+    cy.waitForReact(1000, '.react-loaded');
+    cy.waitUntil(() => Cypress.$('[data-cy="info-message"]').length === 1);
+    cy.waitUntil(() => Cypress.$('[data-cy="info-message"]').length === 0);
+
+    // cy.get('label').contains('Choice B').click();
+    cy.react('TextField', { props: { label: 'Field' } }).type('An example value with selector');
+    cy.react('FieldInstance', { props: { property: 'field-single' } })
+      .contains('Define region')
+      .click();
+
+    cy.react('Atlas')
+      .get('canvas')
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 100, y: 50 })
+      .trigger('mousedown', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 100, y: 50 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 300, y: 150 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 350, y: 200 })
+      .trigger('mouseup');
+
+    cy.wait(1500);
+
+    cy.react('FieldInstance', { props: { property: 'field-single' } })
+      .contains('Define region')
+      .click();
+
+    // // Submit
+    cy.react('Button').contains('Submit').click();
+    cy.get('[data-cy="save-later-button"]').click();
+
+    cy.get('@revision').its('request.body.document.properties.field-single.0.selector.state.x').should('equal', 69);
+    cy.get('@revision').its('request.body.document.properties.field-single.0.selector.state.y').should('equal', 148);
+    cy.get('@revision')
+      .its('request.body.document.properties.field-single.0.selector.state.width')
+      .should('equal', 742);
+    cy.get('@revision')
+      .its('request.body.document.properties.field-single.0.selector.state.height')
+      .should('equal', 445);
+
+    // cy.get('[data-cy="close-add-another"]').should('exist');
+  });
+
+  it('Saving single entity selector', () => {
+    cy.siteLogin('Transcriber');
+    cy.visit('/s/default/madoc/projects/project-with-selectors/manifests/2/c/5/model');
+
+    cy.server();
+    cy.intercept('POST', '/api/crowdsourcing/model/*/revision').as('revision');
+
+    cy.waitForReact(1000, '.react-loaded');
+    cy.waitUntil(() => Cypress.$('[data-cy="info-message"]').length === 1);
+    cy.waitUntil(() => Cypress.$('[data-cy="info-message"]').length === 0);
+
+    cy.react('DefaultInlineEntity', { props: { property: 'entity-single' } }).click();
+
+    cy.get('button').contains('define region').click();
+
+    cy.react('Atlas')
+      .get('canvas')
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 100, y: 50 })
+      .trigger('mousedown', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 100, y: 50 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 300, y: 150 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 350, y: 200 })
+      .trigger('mouseup');
+
+    cy.wait(1500);
+
+    cy.react('Button').contains('Submit').click();
+    cy.get('[data-cy="save-later-button"]').click();
+
+    cy.get('@revision')
+      .its('request.body.document.properties.entity-single.0.selector.revisedBy.0.state.x')
+      .should('equal', 69);
+    cy.get('@revision')
+      .its('request.body.document.properties.entity-single.0.selector.revisedBy.0.state.y')
+      .should('equal', 149);
+    cy.get('@revision')
+      .its('request.body.document.properties.entity-single.0.selector.revisedBy.0.state.width')
+      .should('equal', 741);
+    cy.get('@revision')
+      .its('request.body.document.properties.entity-single.0.selector.revisedBy.0.state.height')
+      .should('equal', 445);
+  });
+
+  it.only('Saving multiple entity selectors', () => {
+    cy.siteLogin('Transcriber');
+    cy.visit('/s/default/madoc/projects/project-with-selectors/manifests/2/c/6/model');
+
+    cy.server();
+    cy.intercept('POST', '/api/crowdsourcing/model/*/revision').as('revision');
+
+    cy.waitForReact(1000, '.react-loaded');
+    cy.waitUntil(() => Cypress.$('[data-cy="info-message"]').length === 1);
+    cy.waitUntil(() => Cypress.$('[data-cy="info-message"]').length === 0);
+
+    cy.react('DefaultInlineEntity', { props: { property: 'entity-multiple' } }).click();
+
+    // Entity 1.
+    cy.react('TextField', { props: { label: 'name' } }).type('entity 1');
+    cy.get('button').contains('define region').click();
+
+    cy.react('Atlas')
+      .get('canvas')
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 100, y: 50 })
+      .trigger('mousedown', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 100, y: 50 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 300, y: 150 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 350, y: 200 })
+      .trigger('mouseup');
+
+    cy.react('BreadcrumbItem').contains('Back').click();
+    cy.react('NewInstanceContainer').contains('Add another Entity multiple').click();
+
+    // Entity 2.
+    cy.react('DefaultInlineEntity', { props: { property: 'entity-multiple' } })
+      .nthNode(1)
+      .click();
+    cy.react('TextField', { props: { label: 'name' } }).type('entity 2');
+    cy.get('button').contains('define region').click();
+
+    cy.react('Atlas')
+      .get('canvas')
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 600, y: 50 })
+      .trigger('mousedown', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 600, y: 50 })
+      .trigger('mousemove', { eventConstructor: 'MouseEvent', button: 0, position: 'topLeft', x: 850, y: 200 })
+      .trigger('mouseup');
+
+    cy.react('Button').contains('Submit').click();
+    cy.get('[data-cy="save-later-button"]').click();
+
+    const root = `request.body.document.properties.entity-multiple`;
+
+    cy.get('@revision').its(`${root}.0.selector.revisedBy.0.state.x`).should('equal', 78);
+    cy.get('@revision').its(`${root}.0.selector.revisedBy.0.state.y`).should('equal', 147);
+    cy.get('@revision').its(`${root}.0.selector.revisedBy.0.state.width`).should('equal', 736);
+    cy.get('@revision').its(`${root}.0.selector.revisedBy.0.state.height`).should('equal', 442);
+    cy.get('@revision').its(`${root}.1.selector.state.x`).should('equal', 1550);
+    cy.get('@revision').its(`${root}.1.selector.state.y`).should('equal', 147);
+    cy.get('@revision').its(`${root}.1.selector.state.width`).should('equal', 736);
+    cy.get('@revision').its(`${root}.1.selector.state.height`).should('equal', 442);
+  });
+
+  it('Saving multiple field selectors', () => {});
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "^8.1.0",
     "cypress": "6",
     "cypress-intellij-reporter": "^0.0.4",
-    "cypress-react-selector": "^2.3.4",
+    "cypress-react-selector": "^2.3.7",
     "cypress-react-unit-test": "^4.17.2",
     "dockerode": "^3.2.1",
     "eslint": "^6.8.0",

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -3554,10 +3554,10 @@ cypress-intellij-reporter@^0.0.4:
   dependencies:
     mocha latest
 
-cypress-react-selector@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/cypress-react-selector/-/cypress-react-selector-2.3.4.tgz#704204cf6d880abfdb0b288a7f833cfd4ab85d3a"
-  integrity sha512-AzGjb+RDTXlZFwh43Fsai3dA5hiPr45awF7Fqwenx3qKMuMnSUdYBIwB6QMeWMLj//3kXO3JFg8dgciZTr/ggQ==
+cypress-react-selector@^2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/cypress-react-selector/-/cypress-react-selector-2.3.7.tgz#26294d182a71b6ed4fb6f705f16662f93b637ceb"
+  integrity sha512-CpgvGuJFumf2WOLEj+5RT2sMgZirkyZAuRCdMzkOu3Gr4+ZIaFtIkVDxS1nhJIHGwDLyiajemct1Sp6kmmlRiA==
   dependencies:
     resq "1.10.0"
 

--- a/services/madoc-ts/package.json
+++ b/services/madoc-ts/package.json
@@ -49,8 +49,8 @@
   "dependencies": {
     "@atlas-viewer/atlas": "1.5.2",
     "@atlas-viewer/iiif-image-api": "^1.2.5",
-    "@capture-models/editor": "^0.13.11",
-    "@capture-models/helpers": "^0.13.6",
+    "@capture-models/editor": "^0.13.13",
+    "@capture-models/helpers": "^0.13.13",
     "@capture-models/types": "^0.13.0",
     "@hyperion-framework/presentation-2-parser": "^1.0.0",
     "@hyperion-framework/parser": "^1.0.0",

--- a/services/madoc-ts/src/frontend/shared/caputre-models/NewEntityInstanceButton.tsx
+++ b/services/madoc-ts/src/frontend/shared/caputre-models/NewEntityInstanceButton.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 const NewInstanceContainer = styled.div`
   text-align: center;
+  margin-bottom: 1em;
 `;
 
 export const NewEntityInstanceButton: React.FC<{

--- a/services/madoc-ts/src/frontend/shared/caputre-models/NewFieldInstanceButton.tsx
+++ b/services/madoc-ts/src/frontend/shared/caputre-models/NewFieldInstanceButton.tsx
@@ -6,6 +6,7 @@ import { BaseField } from '@capture-models/types';
 
 const NewInstanceContainer = styled.div`
   text-align: center;
+  margin-bottom: 1em;
 `;
 
 export const NewFieldButtonInstance: React.FC<{ property: string; path: [string, string][]; field: BaseField }> = ({

--- a/services/madoc-ts/src/frontend/shared/caputre-models/new/components/DefaultManagePropertiesList.tsx
+++ b/services/madoc-ts/src/frontend/shared/caputre-models/new/components/DefaultManagePropertiesList.tsx
@@ -6,7 +6,7 @@ import { useManagePropertyList } from '../hooks/use-manage-property-list';
 import { EditorRenderingConfig } from './EditorSlots';
 
 const NewInstanceContainer = styled.div`
-  margin-bottom: 0.5em;
+  margin-bottom: 1em;
 `;
 
 const InstanceContainer = styled.div`

--- a/services/madoc-ts/src/frontend/shared/caputre-models/new/components/DefaultSubmitButton.tsx
+++ b/services/madoc-ts/src/frontend/shared/caputre-models/new/components/DefaultSubmitButton.tsx
@@ -68,6 +68,7 @@ export const DefaultSubmitButton: React.FC<{ afterSave?: (req: RevisionRequest) 
             ) : (
               <ButtonRow $noMargin>
                 <Button
+                  data-cy="save-later-button"
                   onClick={() => {
                     saveRevision('draft').then(() => {
                       close();

--- a/services/madoc-ts/src/frontend/shared/components/TaskItem.tsx
+++ b/services/madoc-ts/src/frontend/shared/components/TaskItem.tsx
@@ -108,7 +108,12 @@ export const TaskItem: React.FC<{
 }> = props => {
   const { t } = useTranslation();
   return (
-    <TaskItemContainer $onDark={props.$onDark} $selected={props.selected} onClick={props.onClick}>
+    <TaskItemContainer
+      $onDark={props.$onDark}
+      $selected={props.selected}
+      onClick={props.onClick}
+      data-cy="task-list-item"
+    >
       <TaskItemStatus $status={props.status} />
       <TaskItemBody>
         <TaskItemLabel title={props.label}>{props.label}</TaskItemLabel>

--- a/services/madoc-ts/src/frontend/site/features/ProjectCollections.tsx
+++ b/services/madoc-ts/src/frontend/site/features/ProjectCollections.tsx
@@ -19,8 +19,9 @@ export const ProjectCollections: React.FC = () => {
     project: { allowCollectionNavigation, hideProjectCollectionNavigation },
   } = useSiteConfiguration();
 
-  const { data: collections } = apiHooks.getSiteCollection(() =>
-    project && isExact ? [project.collection_id, { type: 'collection' }] : undefined
+  const { data: collections } = apiHooks.getSiteCollection(
+    () => (project && isExact ? [project.collection_id, { type: 'collection' }] : undefined),
+    { forceFetchOnMount: true }
   );
 
   const shownCollections = collections ? collections.collection.items.slice(0, 4) : [];

--- a/services/madoc-ts/src/frontend/site/hooks/use-manifest-task.ts
+++ b/services/madoc-ts/src/frontend/site/hooks/use-manifest-task.ts
@@ -1,7 +1,7 @@
 import { useProjectManifestTasks } from './use-project-manifest-tasks';
 
-export function useManifestTask() {
-  const { data: projectTasks, refetch, isFetched } = useProjectManifestTasks();
+export function useManifestTask(opts?: { refetchOnMount?: boolean }) {
+  const { data: projectTasks, refetch, isFetched } = useProjectManifestTasks(opts);
 
   const manifestTask =
     projectTasks?.manifestTask?.type === 'crowdsourcing-manifest-task' ? projectTasks.manifestTask : undefined;

--- a/services/madoc-ts/src/frontend/site/hooks/use-project-manifest-tasks.ts
+++ b/services/madoc-ts/src/frontend/site/hooks/use-project-manifest-tasks.ts
@@ -1,7 +1,9 @@
 import { apiHooks } from '../../shared/hooks/use-api-query';
 import { useRouteContext } from './use-route-context';
 
-export function useProjectManifestTasks() {
+export function useProjectManifestTasks({ refetchOnMount }: { refetchOnMount?: boolean } = {}) {
   const { projectId, manifestId } = useRouteContext();
-  return apiHooks.getSiteProjectManifestTasks(() => (projectId && manifestId ? [projectId, manifestId] : undefined));
+  return apiHooks.getSiteProjectManifestTasks(() => (projectId && manifestId ? [projectId, manifestId] : undefined), {
+    forceFetchOnMount: refetchOnMount,
+  });
 }

--- a/services/madoc-ts/src/frontend/site/hooks/use-project-manifests.ts
+++ b/services/madoc-ts/src/frontend/site/hooks/use-project-manifests.ts
@@ -28,7 +28,7 @@ export function useProjectManifests() {
           ]
         : undefined,
     {
-      refetchOnMount: true,
+      forceFetchOnMount: true,
       enabled: isExact,
     }
   );

--- a/services/madoc-ts/src/frontend/site/pages/all-tasks.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/all-tasks.tsx
@@ -10,8 +10,6 @@ import {
   OuterLayoutContainer,
 } from '../../shared/atoms/LayoutContainer';
 import { TaskListContainer, TaskListInnerContainer } from '../../shared/atoms/TaskList';
-import { SubjectSnippet } from '../../shared/components/SubjectSnippet';
-import { TaskItem } from "../../shared/components/TaskItem";
 import { useLocalStorage } from '../../shared/hooks/use-local-storage';
 import { useResizeLayout } from '../../shared/hooks/use-resize-layout';
 import { useUser } from '../../shared/hooks/use-site';

--- a/services/madoc-ts/src/frontend/site/pages/view-manifest.tsx
+++ b/services/madoc-ts/src/frontend/site/pages/view-manifest.tsx
@@ -54,7 +54,7 @@ export const ViewManifest: React.FC<{
   const config = useSiteConfiguration();
   const createLocaleString = useCreateLocaleString();
   const manifestOptions = useManifestPageConfiguration();
-  const { userManifestTask, canClaimManifest } = useManifestTask();
+  const { userManifestTask, canClaimManifest } = useManifestTask({ refetchOnMount: true });
   const { isActive } = useProjectStatus();
 
   const directToModelPage = (!!userManifestTask || canClaimManifest) && manifestOptions?.directModelPage;

--- a/services/madoc-ts/themes/.gitignore
+++ b/services/madoc-ts/themes/.gitignore
@@ -1,0 +1,3 @@
+*
+!default-madoc-theme
+!.gitignore

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -345,7 +345,7 @@
   "Unusable": "Unusable",
   "Update": "Update",
   "Update required approvals": "Update required approvals",
-  "User dashboard": "USER DASHBOARD",
+  "User dashboard": "User dashboard",
   "User is already assigned to this task": "User is already assigned to this task",
   "View all contributions": "View all contributions",
   "View in Admin": "View in Admin",

--- a/services/madoc-ts/yarn.lock
+++ b/services/madoc-ts/yarn.lock
@@ -2491,13 +2491,13 @@
     screenfull "^3.3.2"
     whatwg-fetch "^3.0.0"
 
-"@capture-models/editor@^0.13.11":
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/@capture-models/editor/-/editor-0.13.11.tgz#f3f8c1c1d78f95935705ee7d740d304683826ffd"
-  integrity sha512-wU14ovdTdSQ3d7L0z6BH1wu3aa2Q85zd4GTQn6htKDrA71tZ988IED1qo8/dnzdox1sS6gx2SE+Iv1n6qdwaSA==
+"@capture-models/editor@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@capture-models/editor/-/editor-0.13.13.tgz#4955df3cc3c8e40d1acfef0fc3d15645ce1c7a8f"
+  integrity sha512-stT0VjmDbEQh4Z/65D6oqcaIPMUOfiI8d5yRfmz2vKbFZU0+gOAMGbXP1WxmqaU6x5w5gwsRgxlWwWqnBkQryQ==
   dependencies:
     "@atlas-viewer/atlas" "^1.5.2"
-    "@capture-models/helpers" "^0.13.6"
+    "@capture-models/helpers" "^0.13.13"
     "@capture-models/plugin-api" "^0.13.0"
     "@capture-models/types" "^0.13.0"
     "@hyperion-framework/react-vault" "^1.0.0"
@@ -2537,10 +2537,10 @@
     use-async-effect "^2.2.1"
     use-debounce "^3.3.0"
 
-"@capture-models/helpers@^0.13.6":
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/@capture-models/helpers/-/helpers-0.13.6.tgz#5be9ecbebc531a9cb08c8bb3132b25f873b28cd0"
-  integrity sha512-eyECQ4i1KgBTqVu8d1lcOssf141nIcBJwqb9PVf1nPYUzAfYsynVCz9eqdHp45lSW8kpmEQhFo7kGYXDsfHKMg==
+"@capture-models/helpers@^0.13.13":
+  version "0.13.13"
+  resolved "https://registry.yarnpkg.com/@capture-models/helpers/-/helpers-0.13.13.tgz#392a4ea5896ae283beead64adb149563a7ddf654"
+  integrity sha512-pVyr3CGmqKk7PxOOFK5FOfrHOGD6luEtjD9C+pPbaVrcFjOo9iif18p4r+gTfXlU+HjDpuLC8tr3qYxHF/VbWw==
   dependencies:
     "@capture-models/plugin-api" "^0.13.0"
     "@capture-models/types" "^0.13.0"


### PR DESCRIPTION
Implements and tests [these](https://github.com/digirati-co-uk/capture-models/compare/78edea28b7df8451c4352565b0457c7bdf395fa8...master) changes to capture models.

First change was not correctly finding selectors that had been overwritten.
```diff
- current = (property as []).find((field: any) => field.id === id) as any;      
+ current = (property as []).find((field: any) => field.id === id || field.revises === id) as any;
```

The second change ensures the `revisedBy` field is cleared when cloning an entity.
```diff
if (clonedRestOfEntity.selector) {    
  clonedRestOfEntity.selector.id = generateId();    
  clonedRestOfEntity.selector.state = null;    
+ if (clonedRestOfEntity.selector.revisedBy) {      
+    delete clonedRestOfEntity.selector.revisedBy;    
+  }  
}
```

Covered with new tests in the capture model repo to test the data and also end to end tests in Madoc to test from the users position.