### PR TITLE
MUYA-149 - capture model config server overrides

### DIFF
--- a/services/madoc-ts/src/extensions/capture-models/ConfigInjection/ConfigInjection.extension.ts
+++ b/services/madoc-ts/src/extensions/capture-models/ConfigInjection/ConfigInjection.extension.ts
@@ -1,0 +1,87 @@
+import { CaptureModel } from '@capture-models/types';
+import { ApiClient } from '../../../gateway/api';
+import { parseUrn } from '../../../utility/parse-urn';
+import { CaptureModelExtension } from '../extension';
+
+export class ConfigInjectionExtension implements CaptureModelExtension {
+  api: ApiClient;
+  constructor(api: ApiClient) {
+    this.api = api;
+  }
+
+  async onCloneCaptureModel(captureModel: CaptureModel): Promise<CaptureModel> {
+    const derivedFrom = captureModel.derivedFrom;
+    // Nothing we can do if we don't know where the model came from.
+    if (!derivedFrom || !captureModel.target || captureModel.target.length === 0 || !captureModel.id) {
+      return captureModel;
+    }
+
+    const projectsWithModel = await this.api.getProjects(0, { capture_model_id: derivedFrom });
+    const project = (projectsWithModel?.projects || [])[0];
+
+    // No matching project.
+    if (!project) {
+      return captureModel;
+    }
+
+    const manifest = captureModel.target.find(target => (target.type || '').toLowerCase() === 'manifest');
+    const manifestId = manifest ? parseUrn(manifest.id) : null;
+
+    const collection = captureModel.target.find(target => (target.type || '').toLowerCase() === 'collection');
+    const collectionId = collection ? parseUrn(collection.id) : null;
+
+    // No manifest in the target, nothing to do.
+    if (!manifest || !manifestId) {
+      return captureModel;
+    }
+
+    const modelConfig = await this.api.getModelConfiguration({
+      manifest_id: manifestId.id,
+      collection_id: collectionId?.id,
+      project_id: project.id,
+    });
+
+    const modelChanges = modelConfig?.documentChanges;
+
+    // No changes, nothing to do.
+    if (!modelChanges?.length) {
+      return captureModel;
+    }
+
+    const state = { appliedChanges: 0 };
+    const unsupportedKeywords = ['id', 'properties', 'revision', 'revises', 'selector', 'immutable', 'sortOrder'];
+
+    // Apply changes in config object.
+    // Note: Currently this will only support one level deep.
+    for (const change of modelChanges) {
+      // Filter out unsupported changes.
+      if (unsupportedKeywords.indexOf(change.field) !== -1) {
+        continue;
+      }
+      // Get property - this could be improved to do a DOT search or similar.
+      const property = captureModel.document.properties[change.property];
+      // We only support changes first elements, as they were made in the model.
+      const singleFieldOrEntity = property ? property[0] : null;
+      if (!singleFieldOrEntity) {
+        continue;
+      }
+
+      // Equality check.
+      if ((singleFieldOrEntity as any)[change.field] && (singleFieldOrEntity as any)[change.field] === change.value) {
+        continue;
+      }
+
+      // Make the change.
+      (singleFieldOrEntity as any)[change.field] = change.value;
+      state.appliedChanges += 1;
+    }
+
+    console.log(`=> Applying ${state.appliedChanges} changes to capture model`);
+
+    if (state.appliedChanges > 0) {
+      return await this.api.updateCaptureModel(captureModel.id, captureModel);
+    }
+
+    return captureModel;
+  }
+}

--- a/services/madoc-ts/src/extensions/capture-models/ConfigInjection/constants.ts
+++ b/services/madoc-ts/src/extensions/capture-models/ConfigInjection/constants.ts
@@ -1,0 +1,1 @@
+export const MADOC_MODEL_CONFIG = 'madoc-model-config';

--- a/services/madoc-ts/src/extensions/capture-models/ConfigInjection/types.ts
+++ b/services/madoc-ts/src/extensions/capture-models/ConfigInjection/types.ts
@@ -1,0 +1,3 @@
+export type ConfigInjectionSettings = {
+  documentChanges: Array<{ property: string; field: string; value: any }>;
+};

--- a/services/madoc-ts/src/frontend/site/features/CanvasSimpleEditor.tsx
+++ b/services/madoc-ts/src/frontend/site/features/CanvasSimpleEditor.tsx
@@ -224,7 +224,7 @@ export const CanvasSimpleEditor: React.FC<{ revision: string; isComplete?: boole
                 <>
                   <BackToChoicesButton />
 
-                  <div style={{ overflowY: 'auto', padding: '1em 1em 0 1em', fontSize: '13px' }}>
+                  <div style={{ padding: '1em 1em 0 1em', fontSize: '13px' }}>
                     <EditorSlots.TopLevelEditor />
                   </div>
 

--- a/services/madoc-ts/src/gateway/api.ts
+++ b/services/madoc-ts/src/gateway/api.ts
@@ -80,9 +80,9 @@ export class ApiClient {
   private errorRecoveryHandlers: Array<() => void> = [];
   private isDown = false;
   private currentUser?: { scope: string[]; user: { id: string; name?: string } };
-  private captureModelExtensions: ExtensionManager<CaptureModelExtension>;
   private captureModelDataSources: DynamicData[];
   // Public.
+  captureModelExtensions: ExtensionManager<CaptureModelExtension>;
   pageBlocks: PageBlockExtension;
   media: MediaExtension;
   tasks: TaskExtension;
@@ -611,7 +611,7 @@ export class ApiClient {
   }
 
   async getProjectConfiguration(projectId: number, siteUrn: string): Promise<Partial<ProjectConfiguration>> {
-    const projectConfig = await this.getConfiguration<ProjectConfiguration>(MADOC_MODEL_CONFIG, [
+    const projectConfig = await this.getConfiguration<ProjectConfiguration>('madoc', [
       siteUrn,
       `urn:madoc:project:${projectId}`,
     ]);

--- a/services/madoc-ts/src/router.ts
+++ b/services/madoc-ts/src/router.ts
@@ -1,6 +1,7 @@
 import { exportSite } from './routes/admin/export-site';
 import { getMetadataKeys } from './routes/admin/get-metadata-keys';
 import { getMetadataValues } from './routes/admin/get-metadata-values';
+import { getModelConfiguration } from './routes/admin/get-model-configuration';
 import { importSite } from './routes/admin/import-site';
 import { listJobs, runJob } from './routes/admin/list-jobs';
 import { getLocalisation, listLocalisations, updateLocalisation } from './routes/admin/localisation';
@@ -15,6 +16,7 @@ import {
   serveThemeAsset,
   uninstallTheme,
 } from './routes/admin/themes';
+import { updateModelConfiguration } from './routes/admin/update-model-configuration';
 import { updateSiteConfiguration } from './routes/admin/update-site-configuration';
 import { createBlock } from './routes/content/create-block';
 import { createPage } from './routes/content/create-page';
@@ -38,6 +40,7 @@ import { updateCuratedFeed } from './routes/projects/update-curated-feed';
 import { updateProjectNote } from './routes/projects/update-project-note';
 import { fullReindex } from './routes/search/full-reindex';
 import { siteCanvasSource } from './routes/site/site-canvas-reference';
+import { siteModelConfiguration } from './routes/site/site-model-configuration';
 import { sitePageNavigation } from './routes/site/site-page-navigation';
 import { getSlot } from './routes/content/get-slot';
 import { getAllPages } from './routes/content/list-pages';
@@ -146,6 +149,8 @@ export const router = new TypedRouter({
   'cron-jobs': [TypedRouter.GET, '/api/madoc/cron/jobs', listJobs],
   'run-cron-jobs': [TypedRouter.POST, '/api/madoc/cron/jobs/:jobId/run', runJob],
   'update-site-configuration': [TypedRouter.POST, '/api/madoc/configuration', updateSiteConfiguration],
+  'get-model-configuration': [TypedRouter.GET, '/api/madoc/configuration/model', getModelConfiguration],
+  'update-model-configuration': [TypedRouter.POST, '/api/madoc/configuration/model', updateModelConfiguration],
   'update-search-facet-configuration': [
     TypedRouter.POST,
     '/api/madoc/configuration/search-facets',
@@ -366,6 +371,7 @@ export const router = new TypedRouter({
     siteCanvasTasks,
   ],
   'site-configuration': [TypedRouter.GET, '/s/:slug/madoc/api/configuration', siteConfiguration],
+  'site-model-configuration': [TypedRouter.GET, '/s/:slug/madoc/api/configuration/model', siteModelConfiguration],
   'site-page-navigation': [TypedRouter.GET, '/s/:slug/madoc/api/pages/navigation/:paths*', sitePageNavigation],
   'site-facet-configuration': [
     TypedRouter.GET,

--- a/services/madoc-ts/src/routes/admin/get-model-configuration.ts
+++ b/services/madoc-ts/src/routes/admin/get-model-configuration.ts
@@ -1,0 +1,69 @@
+import { getProject } from '../../database/queries/project-queries';
+import { MADOC_MODEL_CONFIG } from '../../extensions/capture-models/ConfigInjection/constants';
+import { ConfigInjectionSettings } from '../../extensions/capture-models/ConfigInjection/types';
+import { api } from '../../gateway/api.server';
+import { Site } from '../../types/omeka/Site';
+import { RouteMiddleware } from '../../types/route-middleware';
+import { NotFound } from '../../utility/errors/not-found';
+import { RequestError } from '../../utility/errors/request-error';
+import { mysql } from '../../utility/mysql';
+import { parseProjectId } from '../../utility/parse-project-id';
+import { optionalUserWithScope } from '../../utility/user-with-scope';
+
+export const getModelConfiguration: RouteMiddleware<{ slug: string }> = async context => {
+  const { siteId } = optionalUserWithScope(context, ['site.admin']);
+  const site = await new Promise<Site>(resolve =>
+    context.mysql.query(mysql`select * from site where site.id = ${siteId}`, (err, data) => {
+      resolve(data[0]);
+    })
+  );
+
+  if (!site || !site.slug) {
+    throw new NotFound('Site not found');
+  }
+
+  const siteApi = api.asUser({ siteId }, { siteSlug: site.slug });
+
+  const parsedId = context.query.project_id ? parseProjectId(context.query.project_id) : null;
+  const project = parsedId ? await context.connection.one(getProject(parsedId, site.id)) : null;
+  const projectId = project ? project.id : null;
+
+  const manifestId = context.query.manifest_id ? Number(context.query.manifest_id) : null;
+  const collectionId = context.query.collection_id ? Number(context.query.collection_id) : null;
+
+  const staticConfiguration: ConfigInjectionSettings = {
+    documentChanges: [],
+  };
+
+  if (Number.isNaN(manifestId) || !manifestId) {
+    throw new RequestError('Invalid or missing manifest ID');
+  }
+
+  if (!projectId) {
+    throw new RequestError('Can only configure models for projects');
+  }
+
+  const configRequest: string[] = [
+    // Site.
+    `urn:madoc:site:${site.id}`,
+    // Project.
+    `urn:madoc:project:${projectId}`,
+  ];
+
+  if (collectionId && !Number.isNaN(collectionId)) {
+    configRequest.push(`urn:madoc:collection:${collectionId}`);
+  }
+
+  configRequest.push(`urn:madoc:manifest:${manifestId}`);
+
+  const configResponse = await siteApi.getConfiguration(MADOC_MODEL_CONFIG, configRequest);
+
+  if (!configResponse || !configResponse.config || !configResponse.config[0]) {
+    context.response.body = staticConfiguration;
+    context.response.status = 200;
+    return;
+  }
+
+  context.response.body = { ...staticConfiguration, ...configResponse.config[0].config_object };
+  context.response.status = 200;
+};

--- a/services/madoc-ts/src/routes/admin/update-model-configuration.ts
+++ b/services/madoc-ts/src/routes/admin/update-model-configuration.ts
@@ -1,0 +1,103 @@
+import { getProject } from '../../database/queries/project-queries';
+import { MADOC_MODEL_CONFIG } from '../../extensions/capture-models/ConfigInjection/constants';
+import { ConfigInjectionSettings } from '../../extensions/capture-models/ConfigInjection/types';
+import { api } from '../../gateway/api.server';
+import { Site } from '../../types/omeka/Site';
+import { RouteMiddleware } from '../../types/route-middleware';
+import { NotFound } from '../../utility/errors/not-found';
+import { RequestError } from '../../utility/errors/request-error';
+import { mysql } from '../../utility/mysql';
+import { parseEtag } from '../../utility/parse-etag';
+import { parseProjectId } from '../../utility/parse-project-id';
+import { userWithScope } from '../../utility/user-with-scope';
+
+export const updateModelConfiguration: RouteMiddleware<{}, Partial<ConfigInjectionSettings>> = async context => {
+  const { id, siteId } = userWithScope(context, ['site.admin']);
+  const site = await new Promise<Site>(resolve =>
+    context.mysql.query(mysql`select * from site where site.id = ${siteId}`, (err, data) => {
+      resolve(data[0]);
+    })
+  );
+
+  if (!site || !site.slug) {
+    throw new NotFound('Site not found');
+  }
+
+  const parsedId = context.query.project_id ? parseProjectId(context.query.project_id) : null;
+  const project = parsedId ? await context.connection.one(getProject(parsedId, site.id)) : null;
+  const projectId = project ? project.id : null;
+
+  const manifestId = context.query.manifest_id ? Number(context.query.manifest_id) : null;
+  const collectionId = context.query.collection_id ? Number(context.query.collection_id) : null;
+
+  const staticConfiguration: ConfigInjectionSettings = {
+    documentChanges: [],
+  };
+
+  if (Number.isNaN(manifestId) || !manifestId) {
+    throw new RequestError('Invalid or missing manifest ID');
+  }
+
+  if (!projectId) {
+    throw new RequestError('Can only configure models for projects');
+  }
+
+  const configRequest: string[] = [
+    // Site.
+    `urn:madoc:site:${site.id}`,
+    // Project.
+    `urn:madoc:project:${projectId}`,
+  ];
+
+  if (collectionId && !Number.isNaN(collectionId)) {
+    configRequest.push(`urn:madoc:collection:${collectionId}`);
+  }
+
+  configRequest.push(`urn:madoc:manifest:${manifestId}`);
+
+  const userApi = api.asUser({ userId: id, siteId }, { siteSlug: site.slug });
+
+  // POST body is the configuration.
+  const configurationRequest = context.requestBody;
+
+  //  - Make query to the config service
+  const rawConfigurationObject = await userApi.getConfiguration<ConfigInjectionSettings>(
+    MADOC_MODEL_CONFIG,
+    configRequest
+  );
+
+  const oldConfiguration = rawConfigurationObject.config[0];
+
+  const newConfiguration = {
+    ...staticConfiguration,
+    ...(oldConfiguration ? oldConfiguration.config_object : {}),
+    ...configurationRequest,
+  };
+
+  // Is it the same context?
+  const isEqual =
+    oldConfiguration &&
+    oldConfiguration.scope &&
+    oldConfiguration.scope.length === configRequest.length &&
+    oldConfiguration.scope.every(val => configRequest.includes(val));
+
+  if (isEqual && oldConfiguration && oldConfiguration.id) {
+    const rawConfiguration = await userApi.getSingleConfigurationRaw(oldConfiguration.id);
+    const etagHeader = rawConfiguration.headers.get('etag');
+    const etag = etagHeader ? parseEtag(etagHeader.toString()) : undefined;
+
+    if (etag) {
+      //  - If it exists, then grab the UUID and update that resource
+      await userApi.replaceConfiguration(oldConfiguration.id, etag, newConfiguration);
+    }
+  } else {
+    try {
+      //  - If it does not exist, then POST the new configuration.
+      await userApi.addConfiguration(MADOC_MODEL_CONFIG, configRequest, newConfiguration);
+    } catch (err) {
+      console.log('Could not save config', err);
+    }
+  }
+
+  context.response.body = newConfiguration;
+};

--- a/services/madoc-ts/src/routes/projects/list-projects.ts
+++ b/services/madoc-ts/src/routes/projects/list-projects.ts
@@ -15,10 +15,12 @@ export const listProjects: RouteMiddleware = async context => {
 
   const page = Number(context.query.page) || 1;
   const rootTaskId = context.query.root_task_id;
+  const modelId = context.query.capture_model_id;
   const onlyPublished = scope.indexOf('site.admin') !== -1 ? castBool(context.request.query.published) : true;
   const projectsPerPage = 10;
 
   const rootTaskQuery = rootTaskId ? sql`and iiif_project.task_id = ${rootTaskId}` : SQL_EMPTY;
+  const modelQuery = modelId ? sql`and iiif_project.capture_model_id = ${modelId}` : SQL_EMPTY;
   const publishedQuery = onlyPublished ? sql`and (iiif_project.status = 1 or iiif_project.status = 2)` : SQL_EMPTY;
 
   const { total } = await context.connection.one(
@@ -26,6 +28,7 @@ export const listProjects: RouteMiddleware = async context => {
       select count(*) as total 
       from iiif_project
       where site_id = ${siteId}
+      ${modelQuery}
       ${rootTaskQuery}
       ${publishedQuery}
     `
@@ -38,6 +41,7 @@ export const listProjects: RouteMiddleware = async context => {
         select *, collection_id as resource_id, iiif_project.id as project_id from iiif_project 
             left join iiif_resource ir on iiif_project.collection_id = ir.id
         where site_id = ${siteId}
+        ${modelQuery}
         ${rootTaskQuery}
         ${publishedQuery}
         limit ${projectsPerPage} offset ${(page - 1) * projectsPerPage}

--- a/services/madoc-ts/src/routes/site/site-model-configuration.ts
+++ b/services/madoc-ts/src/routes/site/site-model-configuration.ts
@@ -1,0 +1,59 @@
+import { getProject } from '../../database/queries/project-queries';
+import { MADOC_MODEL_CONFIG } from '../../extensions/capture-models/ConfigInjection/constants';
+import { ConfigInjectionSettings } from '../../extensions/capture-models/ConfigInjection/types';
+import { RouteMiddleware } from '../../types/route-middleware';
+import { RequestError } from '../../utility/errors/request-error';
+import { parseProjectId } from '../../utility/parse-project-id';
+
+export type SiteModelConfigurationQuery = {
+  manifest_id: number;
+  project_id: string | number;
+  collection_id?: number;
+};
+
+export const siteModelConfiguration: RouteMiddleware<{ slug: string }> = async context => {
+  const { site, siteApi } = context.state;
+
+  const parsedId = context.query.project_id ? parseProjectId(context.query.project_id) : null;
+  const project = parsedId ? await context.connection.one(getProject(parsedId, site.id)) : null;
+  const projectId = project ? project.id : null;
+
+  const manifestId = context.query.manifest_id ? Number(context.query.manifest_id) : null;
+  const collectionId = context.query.collection_id ? Number(context.query.collection_id) : null;
+
+  const staticConfiguration: ConfigInjectionSettings = {
+    documentChanges: [],
+  };
+
+  if (Number.isNaN(manifestId) || !manifestId) {
+    throw new RequestError('Invalid or missing manifest ID');
+  }
+
+  if (!projectId) {
+    throw new RequestError('Can only configure models for projects');
+  }
+
+  const configRequest: string[] = [
+    // Site.
+    `urn:madoc:site:${site.id}`,
+    // Project.
+    `urn:madoc:project:${projectId}`,
+  ];
+
+  if (collectionId && !Number.isNaN(collectionId)) {
+    configRequest.push(`urn:madoc:collection:${collectionId}`);
+  }
+
+  configRequest.push(`urn:madoc:manifest:${manifestId}`);
+
+  const configResponse = await siteApi.getConfiguration(MADOC_MODEL_CONFIG, configRequest);
+
+  if (!configResponse || !configResponse.config || !configResponse.config[0]) {
+    context.response.body = staticConfiguration;
+    context.response.status = 200;
+    return;
+  }
+
+  context.response.body = { ...staticConfiguration, ...configResponse.config[0].config_object };
+  context.response.status = 200;
+};

--- a/services/madoc-ts/src/routes/site/site-projects.ts
+++ b/services/madoc-ts/src/routes/site/site-projects.ts
@@ -6,6 +6,7 @@ export type SiteProjectsQuery = {
   // parent_collection_ids: number[];
   collection_id?: number;
   manifest_id?: number;
+  capture_model_id?: string;
   // canvas_id?: number;
 };
 
@@ -16,7 +17,7 @@ export const siteProjects: RouteMiddleware<{ slug: string }> = async context => 
   const scope = context.state.jwt?.scope || [];
   const onlyPublished = scope.indexOf('site.admin') !== -1 ? castBool(context.request.query.published) : true;
 
-  const { collection_id, manifest_id } = context.query;
+  const { collection_id, manifest_id, capture_model_id } = context.query;
 
   if (manifest_id) {
     context.response.body = await siteApi.getManifestProjects(Number(manifest_id), { published: onlyPublished });
@@ -30,7 +31,7 @@ export const siteProjects: RouteMiddleware<{ slug: string }> = async context => 
     return;
   }
 
-  const projects = await siteApi.getProjects(page, { published: onlyPublished });
+  const projects = await siteApi.getProjects(page, { published: onlyPublished, capture_model_id });
 
   context.response.status = 200;
   context.response.body = projects;

--- a/services/madoc-ts/test-utility/api-mock.ts
+++ b/services/madoc-ts/test-utility/api-mock.ts
@@ -1,5 +1,4 @@
 import { Response } from 'cross-fetch';
-import { LocalisationSiteConfig } from '../src/routes/admin/localisation';
 import { ConfigResponse } from '../src/types/schemas/config-response';
 import { ProjectFull } from '../src/types/schemas/project-full';
 
@@ -76,7 +75,7 @@ Mock this route using the following:
     this.mockStacks[fullUrl][method].push({ response, bodyAssertion });
   }
 
-  mockConfigRequest(projectId: number, config: Partial<ProjectFull['config']>) {
+  mockConfigRequest(projectId: number, config: Partial<ProjectFull['config']>, service = 'madoc', extra = '') {
     const wrapper: ConfigResponse<ProjectFull['config']> = {
       config: [
         {
@@ -88,12 +87,12 @@ Mock this route using the following:
       ],
       query: {
         context: [],
-        service: 'madoc',
+        service: service,
       } as any,
     };
     this.mockRoute(
       'GET',
-      `/api/configurator/query?context=urn%3Amadoc%3Asite%3A1&context=urn%3Amadoc%3Aproject%3A${projectId}&service=madoc`,
+      `/api/configurator/query?context=urn%3Amadoc%3Asite%3A1&context=urn%3Amadoc%3Aproject%3A${projectId}${extra}&service=${service}`,
       wrapper
     );
   }


### PR DESCRIPTION
Just before the model is created (same step OCR is created) it will check the config server for objects that look like this:
```
{
  "documentChanges": [
    {
      "property": "verses",
      "field": "dataSource",
      "value": "https://gist.githubusercontent.com/stephenwf/[ ... ]/completions-custom.json"
    }
  ]
}
```

Which effectively translates to:
```
captureModel.document.properties.verses[0].dataSource = 'https://gist[...]/completions-custom.json'
```
Only works on top level capture model fields, and there’s a blacklist so this can’t ruin models. If it’s invalid, it just skips it. Config server let’s us configure it at any level, but I’ve limited it to only manifests. So you can say “Change this field in this capture model on all of the images in this manifest, in this project”