### PR TITLE
Update LoginController.php

### DIFF
--- a/services/madoc/packages/public-user/src/Controller/LoginController.php
+++ b/services/madoc/packages/public-user/src/Controller/LoginController.php
@@ -330,7 +330,7 @@ class LoginController extends AbstractActionController
         $perms = new SitePermission();
         $perms->setSite($invitation ? $invitation->siteId : $site->id());
         $perms->setUser($user->getId());
-        $perms->setRole($invitation ? $invitation->siteRole : 'viewer');
+        $perms->setRole($invitation ? $invitation->siteRole :  strtolower($role) );
 
         $this->entityManager->persist($perms);
         $this->entityManager->flush();


### PR DESCRIPTION
Default role is not fixed 'viewer' but a site setting. Lowercase is needed because the global transcriber role is 'Transcriber', the site role is 'transcriber'.