### PR TITLE
2.0.2 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug with 404 status not being handled correctly
 - Fixed bug with `null` metadata values breaking admin
 - Prevent error when deleting collection (task related)
+- Fixed bug with invalid i18n configuration
 
 ## [2.0.1](https://github.com/digirati-co-uk/madoc-platform/releases/tag/v2.0.1) - 2021-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug with `null` metadata values breaking admin
 - Prevent error when deleting collection (task related)
 - Fixed bug with invalid i18n configuration
+- Fixed bug with missing sites when reducing statistics
 
 ## [2.0.1](https://github.com/digirati-co-uk/madoc-platform/releases/tag/v2.0.1) - 2021-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug where multiple search indexing or OCR tasks would be triggered
 - Fixed retry of tasks when added to queue
 - Fixed bug with 404 status not being handled correctly
-
+- Fixed bug with `null` metadata values breaking admin
 
 ## [2.0.1](https://github.com/digirati-co-uk/madoc-platform/releases/tag/v2.0.1) - 2021-11-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed retry of tasks when added to queue
 - Fixed bug with 404 status not being handled correctly
 - Fixed bug with `null` metadata values breaking admin
+- Prevent error when deleting collection (task related)
 
 ## [2.0.1](https://github.com/digirati-co-uk/madoc-platform/releases/tag/v2.0.1) - 2021-11-19
 

--- a/services/madoc-ts/src/frontend/shared/components/MetaDataDisplay.tsx
+++ b/services/madoc-ts/src/frontend/shared/components/MetaDataDisplay.tsx
@@ -129,7 +129,7 @@ const MetadataContainer = styled.tr<{ $variation?: 'list' | 'table' }>`
 
 export const MetaDataDisplay: React.FC<{
   config?: FacetConfig[];
-  metadata?: Array<{ label: InternationalString; value: InternationalString }>;
+  metadata?: Array<{ label: InternationalString; value: InternationalString } | null>;
   variation?: 'table' | 'list';
   labelStyle?: 'muted' | 'bold' | 'caps' | 'small-caps';
   labelWidth?: number;
@@ -156,7 +156,12 @@ export const MetaDataDisplay: React.FC<{
     for (const item of metadata) {
       const labels = item && item.label ? Object.values(item.label) : [];
       for (const label of labels) {
-        if (label && label.length && (flatKeys.indexOf(`metadata.${label[0]}`) !== -1 || flatKeys.length === 0)) {
+        if (
+          label &&
+          label.length &&
+          (flatKeys.indexOf(`metadata.${label[0]}`) !== -1 || flatKeys.length === 0) &&
+          item
+        ) {
           const key = `metadata.${label[0]}`;
           map[key] = map[key] ? map[key] : [];
           map[key].push(item);
@@ -227,6 +232,9 @@ export const MetaDataDisplay: React.FC<{
       <tbody>
         {metadata && metadata.length
           ? metadata.map((metadataItem, idx: number) => {
+              if (!metadataItem) {
+                return null; // null items.
+              }
               return (
                 <MetadataContainer key={idx} $variation={variation}>
                   <MetaDataKey

--- a/services/madoc-ts/src/repository/site-user-repository.ts
+++ b/services/madoc-ts/src/repository/site-user-repository.ts
@@ -1035,12 +1035,16 @@ export class SiteUserRepository extends BaseRepository {
     }
 
     const stats = resources.reduce((map, next) => {
-      map[next.site_id][next.resource_type] = next.total_items;
+      if (map[next.site_id]) {
+        map[next.site_id][next.resource_type] = next.total_items;
+      }
       return map;
     }, siteMap);
 
     for (const project of projects) {
-      stats[project.site_id].projects = project.total_projects;
+      if (stats[project.site_id]) {
+        stats[project.site_id].projects = project.total_projects;
+      }
     }
 
     return stats;

--- a/services/madoc-ts/src/routes/iiif/collections/delete-collection.ts
+++ b/services/madoc-ts/src/routes/iiif/collections/delete-collection.ts
@@ -54,7 +54,12 @@ export async function deleteCollection(
     }
 
     if (deletionSummary.tasks > 0 || deletionSummary.parentTasks > 0) {
-      await siteApi.batchDeleteTasks({ resourceId: collectionId, subject: `urn:madoc:collection:${collectionId}` });
+      try {
+        await siteApi.batchDeleteTasks({ resourceId: collectionId, subject: `urn:madoc:collection:${collectionId}` });
+      } catch (e) {
+        // Some old collections may not be able to delete in batch like this.
+        // Leave as no-op. It may result in some lingering tasks.
+      }
     }
 
     if (deletionSummary.search.indexed && deletionSummary.search.id) {


### PR DESCRIPTION
- Fixed bug with `null` metadata values breaking admin
- Prevent error when deleting collection (task related)
- Fixed bug with invalid i18n configuration
- Fixed bug with missing sites when reducing statistics