### PR TITLE
MAD-1091 Added new "Disable preview popup" project configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added project option for disabling "save for later"
 - Added "Selector is required" to capture model editor
 - Added required selector styling using disabled field sets.
+- Added new "Disable preview popup" project configuration option
 
 ### Changed
 - The link in the top bar now always links to the site (previously the admin for admins).

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultPostSubmission.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultPostSubmission.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useRelativeLinks } from '../../../../site/hooks/use-relative-links';
 import { useRouteContext } from '../../../../site/hooks/use-route-context';
-import { Button } from '../../../navigation/Button';
+import { InfoMessage } from '../../../callouts/InfoMessage';
+import { Button, ButtonRow } from '../../../navigation/Button';
 import { SnippetStructure } from '../../../components/StructureSnippet';
 import { useManifestStructure } from '../../../hooks/use-manifest-structure';
 import { HrefLink } from '../../../utility/href-link';
+import { EditorRenderingConfig } from './EditorSlots';
 
-export const DefaultPostSubmission: React.FC<{ subRoute?: string }> = () => {
+export const DefaultPostSubmission: EditorRenderingConfig['PostSubmission'] = ({ onContinue, stacked }) => {
   const { t } = useTranslation();
   const { manifestId, canvasId, projectId } = useRouteContext();
   const structure = useManifestStructure(manifestId);
@@ -21,13 +23,38 @@ export const DefaultPostSubmission: React.FC<{ subRoute?: string }> = () => {
 
   const next = idx < structure.data.items.length - 1 ? structure.data.items[idx + 1] : null;
 
+  const buttonRow = (
+    <ButtonRow>
+      {onContinue ? (
+        <Button data-cy="add-another" onClick={onContinue}>
+          {t('Continue working')}
+        </Button>
+      ) : null}
+      {next ? (
+        <Button
+          data-cy="go-to-next-image"
+          $primary
+          as={HrefLink}
+          href={createLink({ canvasId: next.id, subRoute: 'model' })}
+        >
+          {t('Next image')}
+        </Button>
+      ) : null}
+    </ButtonRow>
+  );
+
   if (!next) {
-    return <div>{t('Thanks for you submission')}</div>;
+    return (
+      <div>
+        <InfoMessage $banner>{t('Thanks for your submission')}</InfoMessage>
+        <div style={{ padding: '0 1em' }}>{buttonRow}</div>
+      </div>
+    );
   }
 
   return (
     <div>
-      <div style={{ display: 'flex' }}>
+      <div style={{ display: 'flex', flexDirection: stacked ? 'column' : 'row', padding: '0 1em' }}>
         <div style={{ flex: '1 1 0px' }}>
           <h3>{t('Contribution submitted')}</h3>
           <p>{t('Keep working on this image or move on to next image')}</p>
@@ -41,16 +68,9 @@ export const DefaultPostSubmission: React.FC<{ subRoute?: string }> = () => {
               subRoute: 'model',
             })}
           />
-          <br />
-          <Button
-            data-cy="go-to-next-image"
-            $primary
-            as={HrefLink}
-            href={createLink({ canvasId: next.id, subRoute: 'model' })}
-          >
-            {t('Next image')}
-          </Button>
+          {stacked ? null : buttonRow}
         </div>
+        {stacked ? buttonRow : null}
       </div>
     </div>
   );

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/EditorSlots.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/EditorSlots.tsx
@@ -72,7 +72,11 @@ export type EditorRenderingConfig = {
     captureModel?: CaptureModel;
   }>;
   PreviewSubmission: React.FC;
-  PostSubmission: React.FC;
+  PostSubmission: React.FC<{
+    stacked?: boolean;
+    onContinue?: () => void;
+    subRoute?: string;
+  }>;
 };
 
 export type ProfileConfig = Partial<Omit<EditorRenderingConfig, 'configuration'>>;
@@ -288,7 +292,7 @@ const EditorWrapper: EditorRenderingConfig['EditorWrapper'] = props => {
 const PostSubmission: EditorRenderingConfig['PostSubmission'] = props => {
   const Slots = useSlotContext();
 
-  return <Slots.PostSubmission>{props.children}</Slots.PostSubmission>;
+  return <Slots.PostSubmission {...props}>{props.children}</Slots.PostSubmission>;
 };
 
 const InlineEntity: EditorRenderingConfig['InlineEntity'] = props => {

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/SubmitWithoutPreview.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/SubmitWithoutPreview.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMutation } from 'react-query';
+import { useRouteContext } from '../../../../site/hooks/use-route-context';
+import { Button, ButtonRow } from '../../../navigation/Button';
+import { useViewerSaving } from '../../../hooks/use-viewer-saving';
+import { Revisions } from '../../editor/stores/revisions/index';
+import { useDeselectRevision } from '../hooks/use-deselect-revision';
+import { EditorRenderingConfig, useSlotContext } from './EditorSlots';
+
+export const SubmitWithoutPreview: EditorRenderingConfig['SubmitButton'] = ({ afterSave }) => {
+  const { t } = useTranslation();
+  const routeContext = useRouteContext();
+  const Slots = useSlotContext();
+  const { disableSaveForLater = false } = Slots.configuration;
+  const currentRevision = Revisions.useStoreState(s => s.currentRevision);
+  const updateFunction = useViewerSaving(
+    afterSave
+      ? async revisionRequest => {
+          await afterSave({
+            revisionRequest,
+            context: routeContext,
+          });
+        }
+      : undefined
+  );
+  const deselectRevision = useDeselectRevision();
+
+  const [saveRevision, { isLoading, reset }] = useMutation(async (status: string) => {
+    if (!currentRevision) {
+      throw new Error(t('Unable to save your submission'));
+    }
+
+    try {
+      // Change this to "draft" to save for later.
+      await updateFunction(currentRevision, status);
+    } catch (e) {
+      console.error(e);
+      throw new Error(t('Unable to save your submission'));
+    }
+  });
+
+  if (!currentRevision) {
+    return null;
+  }
+
+  return (
+    <div style={{ padding: '0.5em 1em' }}>
+      <ButtonRow>
+        {!disableSaveForLater ? (
+          <Button
+            data-cy="save-later-button"
+            disabled={isLoading}
+            onClick={() => {
+              saveRevision('draft').then(() => {
+                // deselectRevision();
+                // No need for this.
+              });
+            }}
+          >
+            {t('Save for later')}
+          </Button>
+        ) : null}
+        <Button
+          data-cy="publish-button"
+          disabled={isLoading}
+          $primary
+          onClick={() => {
+            saveRevision('submitted').then(() => {
+              deselectRevision();
+              reset();
+            });
+          }}
+        >
+          {isLoading ? t('Saving...') : t('Submit')}
+        </Button>
+      </ButtonRow>
+    </div>
+  );
+};

--- a/services/madoc-ts/src/frontend/shared/configuration/site-config.ts
+++ b/services/madoc-ts/src/frontend/shared/configuration/site-config.ts
@@ -209,6 +209,10 @@ export const siteConfigurationModel: {
         label: 'Disable save for later button',
         value: 'disableSaveForLater',
       },
+      {
+        label: 'Disable preview popup (direct submit)',
+        value: 'disablePreview',
+      },
     ],
   },
   projectPageOptions: {

--- a/services/madoc-ts/src/types/schemas/project-configuration.ts
+++ b/services/madoc-ts/src/types/schemas/project-configuration.ts
@@ -43,6 +43,7 @@ export type ProjectConfiguration = {
     preventContributionAfterManifestUnassign?: boolean;
     hideViewerControls?: boolean;
     disableSaveForLater?: boolean;
+    disablePreview?: boolean;
   };
   projectPageOptions?: {
     hideStartContributing?: boolean;

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -124,6 +124,7 @@
   "Continue submission ({{count}})": "Continue submission ({{count}})",
   "Continue submission ({{count}})_plural": "Continue submission ({{count}})",
   "Continue where you left off": "Continue where you left off",
+  "Continue working": "Continue working",
   "Contribute": "Contribute",
   "Contribute to random canvas": "Contribute to random canvas",
   "Contribute to the next image": "Contribute to the next image",


### PR DESCRIPTION
Makes save buttons inline on the page:
![image](https://user-images.githubusercontent.com/8266711/158411384-f21489f4-cafa-47c4-bfc4-2b54d5f54f1a.png)

Submit will submit for review directly, before showing the "Post submission" screen
![image](https://user-images.githubusercontent.com/8266711/158411489-cdec608c-95af-4aa8-aa97-0cdc19eafc35.png)

Also compatible with #534 
![image](https://user-images.githubusercontent.com/8266711/158411580-e3b3388d-1b6f-47b6-9167-77694e0ef764.png)
