### PR TITLE
MAD-1092 - Disable submit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added project option for disabling "save for later"
 - Added "Selector is required" to capture model editor
 - Added required selector styling using disabled field sets.
+- Added "canSubmit" which will disable the Submit button if required selectors are not complete
 
 ### Changed
 - The link in the top bar now always links to the site (previously the admin for admins).

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultSubmitButton.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultSubmitButton.tsx
@@ -10,7 +10,7 @@ import { Revisions } from '../../editor/stores/revisions/index';
 import { useDeselectRevision } from '../hooks/use-deselect-revision';
 import { EditorRenderingConfig, useSlotContext } from './EditorSlots';
 
-export const DefaultSubmitButton: EditorRenderingConfig['SubmitButton'] = ({ afterSave }) => {
+export const DefaultSubmitButton: EditorRenderingConfig['SubmitButton'] = ({ afterSave, canSubmit = true }) => {
   const { t } = useTranslation();
   const routeContext = useRouteContext();
   const Slots = useSlotContext();
@@ -93,7 +93,7 @@ export const DefaultSubmitButton: EditorRenderingConfig['SubmitButton'] = ({ aft
                 ) : null}
                 <Button
                   data-cy="publish-button"
-                  disabled={isLoading}
+                  disabled={isLoading || !canSubmit}
                   $primary
                   onClick={() => {
                     saveRevision('submitted').then(() => {

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/EditorSlots.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/EditorSlots.tsx
@@ -3,6 +3,7 @@ import { RouteContext } from '../../../../site/hooks/use-route-context';
 import { CaptureModel } from '../../types/capture-model';
 import { BaseField } from '../../types/field-types';
 import { RevisionRequest } from '../../types/revision-request';
+import { useCanSubmit } from '../hooks/use-can-submit';
 import { useCurrentEntity } from '../hooks/use-current-entity';
 import { DefaultAdjacentNavigation } from './DefaultAdjacentNavigation';
 import { DefaultBreadcrumbs } from './DefaultBreadcrumbs';
@@ -70,6 +71,7 @@ export type EditorRenderingConfig = {
     afterSave?: (req: { revisionRequest: RevisionRequest; context: RouteContext }) => void | Promise<void>;
     saveOnNavigate?: boolean;
     captureModel?: CaptureModel;
+    canSubmit?: boolean;
   }>;
   PreviewSubmission: React.FC;
   PostSubmission: React.FC;
@@ -261,12 +263,14 @@ const Choice: EditorRenderingConfig['Choice'] = props => {
 
 const SubmitButton: EditorRenderingConfig['SubmitButton'] = props => {
   const Slots = useSlotContext();
+  const canSubmit = useCanSubmit();
 
   return (
     <Slots.SubmitButton
       saveOnNavigate={Slots.configuration.saveOnNavigate}
       captureModel={props.captureModel}
       afterSave={props.afterSave}
+      canSubmit={typeof props.canSubmit !== 'undefined' ? props.canSubmit : canSubmit}
     >
       {props.children}
     </Slots.SubmitButton>

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/SubmitWithoutPreview.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/SubmitWithoutPreview.tsx
@@ -8,7 +8,7 @@ import { Revisions } from '../../editor/stores/revisions/index';
 import { useDeselectRevision } from '../hooks/use-deselect-revision';
 import { EditorRenderingConfig, useSlotContext } from './EditorSlots';
 
-export const SubmitWithoutPreview: EditorRenderingConfig['SubmitButton'] = ({ afterSave }) => {
+export const SubmitWithoutPreview: EditorRenderingConfig['SubmitButton'] = ({ afterSave, canSubmit = true }) => {
   const { t } = useTranslation();
   const routeContext = useRouteContext();
   const Slots = useSlotContext();
@@ -63,7 +63,7 @@ export const SubmitWithoutPreview: EditorRenderingConfig['SubmitButton'] = ({ af
         ) : null}
         <Button
           data-cy="publish-button"
-          disabled={isLoading}
+          disabled={isLoading || !canSubmit}
           $primary
           onClick={() => {
             saveRevision('submitted').then(() => {

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/hooks/use-can-submit.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/hooks/use-can-submit.ts
@@ -1,0 +1,41 @@
+import { Revisions } from '../../editor/stores/revisions/index';
+import { BaseSelector } from '../../types/selector-types';
+
+export function useCanSubmit() {
+  const selectorsToValidate: BaseSelector[] = [];
+
+  const revision = Revisions.useStoreState(state => state.currentRevision);
+
+  const revisionDocument = revision && revision.document ? revision.document : null;
+  const properties =
+    revisionDocument && revisionDocument.type === 'entity' ? Object.keys(revisionDocument.properties) : [];
+
+  // Strategy for can submit.
+  // 1. Find the top-level we are editing - unrolled entity/model root
+  // 2. Create a list of selectors
+  // 3. Make sure they are all valid.
+  if (revisionDocument) {
+    for (const property of properties) {
+      const fieldOrEntity = revisionDocument.properties[property];
+      if (fieldOrEntity && fieldOrEntity.length) {
+        for (const singleFieldOrEntity of fieldOrEntity) {
+          if (singleFieldOrEntity.selector) {
+            selectorsToValidate.push(singleFieldOrEntity.selector);
+          }
+        }
+      }
+    }
+  }
+
+  if (true as boolean) {
+    return false;
+  }
+
+  for (const selector of selectorsToValidate) {
+    if (selector && selector.required && !selector.state) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/hooks/use-can-submit.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/hooks/use-can-submit.ts
@@ -1,4 +1,5 @@
 import { Revisions } from '../../editor/stores/revisions/index';
+import { resolveSelector } from '../../helpers/resolve-selector';
 import { BaseSelector } from '../../types/selector-types';
 
 export function useCanSubmit() {
@@ -27,13 +28,12 @@ export function useCanSubmit() {
     }
   }
 
-  if (true as boolean) {
-    return false;
-  }
-
-  for (const selector of selectorsToValidate) {
-    if (selector && selector.required && !selector.state) {
-      return false;
+  if (revision) {
+    for (const selector of selectorsToValidate) {
+      const resolved = resolveSelector(selector, revision?.revision.id);
+      if (resolved && resolved.required && !resolved.state) {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
Added "canSubmit" which will disable the Submit button if required selectors are not complete. This will operate on two selectors

* Top level entity selectors
* Top level field selectors

This works if you have `allowMultiple=true` so if you set your capture model field to required you should ensure you understand how this will affect users filling in your model. It does **not**  work with selectors nested further than the top level.

It _should_ work with modelRoot changes, as this changes the document in the revision, if not that will be fixed.