### PR TITLE
MAD-1097 Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing OCR listed
 - Styling of "Suggest edit" to be clearer
 - Styling of "Breadcrumbs" and labelling
+- Fixed default selected field "type" - it is now "text-field" making models quicker to create
+- Fixed issue where you could not de-select an entity selector
+- Fixed auto-selecting the "define" region when using editing an existing region
 
 ### Added
 - Added refresh on 500 error page (usually appears during deployment)
@@ -29,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new "international-field" type to capture models
 - Added new "Disable preview popup" project configuration option
 - Added support for choosing "Model root" in capture model editor
+- Added "tiny" variation of image wrapper [dev]
+- Added preview for entity lists using selector if it's available
+- Added "confirm" to deselect or confirm the current selector
 
 ### Changed
 - The link in the top bar now always links to the site (previously the admin for admins).
@@ -41,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed back to choices styling
 
 ### Removed
-
+- Removed auto-save by default, causing errors and no immediate feedback to the user
 
 ## [2.0.3](https://github.com/digirati-co-uk/madoc-platform/releases/tag/v2.0.3) - 2022-02-17
 

--- a/services/madoc-ts/src/frontend/shared/atoms/Images.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/Images.tsx
@@ -1,10 +1,12 @@
 import styled, { css } from 'styled-components';
 
-export const CroppedImage = styled.div<{ $size?: 'small' | 'large'; $fluid?: boolean; $covered?: boolean }>`
+export const CroppedImage = styled.div<{ $size?: 'tiny' | 'small' | 'large'; $fluid?: boolean; $covered?: boolean }>`
   background: #000;
   padding: 2px;
   height: ${props => {
     switch (props.$size) {
+      case 'tiny':
+        return '50px';
       case 'small':
         return '150px';
       case 'large':
@@ -15,6 +17,8 @@ export const CroppedImage = styled.div<{ $size?: 'small' | 'large'; $fluid?: boo
   }};
   width: ${props => {
     switch (props.$size) {
+      case 'tiny':
+        return '50px';
       case 'small':
         return '150px';
       case 'large':

--- a/services/madoc-ts/src/frontend/shared/capture-models/DocumentPreview.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/DocumentPreview.tsx
@@ -1,14 +1,21 @@
-import React, { ComponentClass, FunctionComponent, useMemo } from 'react';
+import React, { ComponentClass, FunctionComponent, ReactNode, useMemo } from 'react';
 import { FieldPreview } from './editor/components/FieldPreview/FieldPreview';
 import { isEntity } from './helpers/is-entity';
 import { CaptureModel } from './types/capture-model';
 import { BaseField } from './types/field-types';
 import { getEntityLabel } from './utility/get-entity-label';
 
-export const DocumentPreview: React.FC<{
+export function DocumentPreview({
+  entity,
+  as,
+  wrapper = a => a,
+  children,
+}: {
+  wrapper?: (element: React.ReactElement) => React.ReactElement;
   entity: CaptureModel['document'] | BaseField;
   as?: FunctionComponent<any> | ComponentClass<any> | string;
-}> = ({ entity, as, children }) => {
+  children: any;
+}) {
   const filteredLabeledBy = useMemo(() => {
     if (isEntity(entity)) {
       return getEntityLabel(entity, undefined, true);
@@ -19,11 +26,11 @@ export const DocumentPreview: React.FC<{
 
   if (isEntity(entity)) {
     if (!filteredLabeledBy) {
-      return <>{children}</>;
+      return wrapper(children);
     }
 
-    return <>{filteredLabeledBy}</>;
+    return wrapper(<>{filteredLabeledBy}</>);
   }
 
-  return <FieldPreview as={as} field={entity} />;
-};
+  return wrapper(<FieldPreview as={as} field={entity} />);
+}

--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/atoms/Grid.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/atoms/Grid.tsx
@@ -9,8 +9,12 @@ export const Grid = styled.div<{ padded?: boolean }>`
       padding: 0.75em;
     `}
 `;
-export const GridColumn = styled.div<{ fluid?: boolean; half?: boolean }>`
-  padding: 0.75em;
+export const GridColumn = styled.div<{ fluid?: boolean; half?: boolean; center?: boolean; padded?: boolean }>`
+  ${({ padded = true }) =>
+    padded &&
+    css`
+      padding: 0.75em;
+    `}
   ${props =>
     props.fluid &&
     css`
@@ -20,6 +24,11 @@ export const GridColumn = styled.div<{ fluid?: boolean; half?: boolean }>`
     props.half &&
     css`
       width: 50%;
+    `}
+  ${props =>
+    props.center &&
+    css`
+      align-self: center;
     `}
 `;
 export const GridRow = styled.div`

--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/components/ChooseFieldButton/ChooseFieldButton.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/components/ChooseFieldButton/ChooseFieldButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { PluginContext } from '../../../plugin-api/context';
 import { Dropdown } from '../../atoms/Dropdown';
 
@@ -13,7 +13,14 @@ type Props = {
 
 export const ChooseFieldButton: React.FC<Props> = ({ onChange, fieldType }) => {
   const { fields } = useContext(PluginContext);
-  const [value, setValue] = useState(fieldType || fields[0]?.type);
+  const textSelector = fields['text-field'];
+  const [value, setValue] = useState(fieldType || (textSelector ? 'text-field' : undefined));
+
+  useEffect(() => {
+    onChange(value);
+    // Adding onChange here results in infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   return (
     <Dropdown
@@ -22,7 +29,6 @@ export const ChooseFieldButton: React.FC<Props> = ({ onChange, fieldType }) => {
       selection
       value={value}
       onChange={v => {
-        onChange(v);
         setValue(v);
       }}
       options={

--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/components/ChooseSelectorButton/ChooseSelectorButton.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/components/ChooseSelectorButton/ChooseSelectorButton.tsx
@@ -13,8 +13,7 @@ type Props = {
 export const ChooseSelectorButton: React.FC<Props> = ({ value: initialValue, onChange }) => {
   const { t } = useTranslation();
   const { selectors } = useContext(PluginContext);
-  const [value, setValue] = useState(initialValue);
-
+  const [value, setValue] = useState<string | undefined>(initialValue || '');
   return (
     <div>
       <Dropdown

--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/selector-types/BoxSelector/BoxSelector.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/selector-types/BoxSelector/BoxSelector.tsx
@@ -48,6 +48,7 @@ export const BoxSelector: SelectorComponent<BoxSelectorProps> = ({
   chooseSelector,
   clearSelector,
   updateSelector,
+  hideSelector,
   readOnly,
   ...props
 }) => {
@@ -79,6 +80,11 @@ export const BoxSelector: SelectorComponent<BoxSelectorProps> = ({
             <div>
               {t('Move and resize the highlighted box on the image to choose your selection.')}
               <br />
+              {props.state && clearSelector ? (
+                <SelectorButton inline={true} size="small" onClick={() => clearSelector()} style={{ marginRight: 10 }}>
+                  {t('confirm')}
+                </SelectorButton>
+              ) : null}
               {props.state && updateSelector ? (
                 <SelectorButton
                   inline={true}

--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/stores/selectors/selector-hooks.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/stores/selectors/selector-hooks.ts
@@ -154,6 +154,7 @@ export function useSelectorHandlers() {
 export function useCurrentSelector(contentType: string, defaultState: any = null) {
   const { updateSelectorPreview } = useSelectorHandlers();
   const updateSelector = Revisions.useStoreActions(a => a.updateCurrentSelector);
+  const clearSelector = Revisions.useStoreActions(a => a.clearSelector);
 
   return useSelector(
     Revisions.useStoreState(s => s.resolvedSelectors.find(({ id }) => id === s.selector.currentSelectorId)),
@@ -164,6 +165,7 @@ export function useCurrentSelector(contentType: string, defaultState: any = null
       ),
       updateSelectorPreview,
       updateSelector,
+      clearSelector,
       defaultState,
     }
   );

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultBreadcrumbs.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultBreadcrumbs.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { BreadcrumbDivider, BreadcrumbItem, BreadcrumbList } from '../../../components/Breadcrumbs';
 import { EditorRenderingConfig } from './EditorSlots';
 import { HomeIcon } from '../../../icons/HomeIcon';
-import {useBreads} from '../../hooks/use-breads';
+import { useBreads } from '../../hooks/use-breads';
 
 export const DefaultBreadcrumbs: EditorRenderingConfig['Breadcrumbs'] = () => {
   const { breads, revisionPopTo, fieldSelected, revisionDeselectField } = useBreads();
@@ -24,7 +24,7 @@ export const DefaultBreadcrumbs: EditorRenderingConfig['Breadcrumbs'] = () => {
       {breads.map((s, n) => {
         const name = n === 0 ? <HomeIcon title={s.name} /> : s.name;
         return (
-          <React.Fragment key={s.id}>
+          <React.Fragment key={n}>
             <BreadcrumbItem active={s.active} $icon={n === 0}>
               {!s.active ? <a onClick={() => selectItem(s.id, n)}>{name}</a> : name}
             </BreadcrumbItem>

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultInlineEntity.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultInlineEntity.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { CroppedImage } from '../../../atoms/Images';
 import { InputAsCard } from '../../../form/Input';
+import { Grid, GridColumn } from '../../editor/atoms/Grid';
 import { RoundedCard } from '../../editor/components/RoundedCard/RoundedCard';
+import { Revisions } from '../../editor/stores/revisions/index';
+import { SelectorPreview } from '../../inspector/ViewDocument';
 import { getEntityLabel } from '../../utility/get-entity-label';
 import { ModifiedStatus } from '../features/ModifiedStatus';
 import { useEntityDetails } from '../hooks/use-entity-details';
+import { useResolvedSelector } from '../hooks/use-resolved-selector';
 import { EditorRenderingConfig, useProfileOverride, useSlotContext } from './EditorSlots';
 import { DocumentPreview } from '../../DocumentPreview';
 
@@ -11,11 +16,39 @@ export const DefaultInlineEntity: EditorRenderingConfig['InlineEntity'] = props 
   const { entity, chooseEntity, onRemove, canRemove } = props;
   const { configuration } = useSlotContext();
   const { isModified } = useEntityDetails(entity);
+  const previewData = Revisions.useStoreState(s => s.selector.selectorPreviewData);
+  const [selector] = useResolvedSelector(entity);
   const ProfileSpecificComponent = useProfileOverride('InlineEntity');
 
   if (ProfileSpecificComponent) {
     return <ProfileSpecificComponent {...props} />;
   }
+
+  const documentPreview = (
+    <>
+      {isModified && <ModifiedStatus />}
+      <DocumentPreview
+        entity={entity}
+        wrapper={element => (
+          <Grid style={{ padding: '0 .5em' }}>
+            {selector && previewData[selector.id] ? (
+              <CroppedImage $size="tiny" style={{ marginRight: '1em' }}>
+                <img src={previewData[selector.id]} />
+              </CroppedImage>
+            ) : null}
+            <GridColumn center fluid padded={false}>
+              {element}
+            </GridColumn>
+          </Grid>
+        )}
+      >
+        {getEntityLabel(
+          entity,
+          <span style={{ color: '#999' }}>No value {configuration.allowEditing ? '(click to edit)' : null}</span>
+        )}
+      </DocumentPreview>
+    </>
+  );
 
   if (canRemove && onRemove) {
     return (
@@ -26,26 +59,14 @@ export const DefaultInlineEntity: EditorRenderingConfig['InlineEntity'] = props 
         onClick={chooseEntity}
         onRemove={canRemove ? onRemove : undefined}
       >
-        {isModified && <ModifiedStatus />}
-        <DocumentPreview entity={entity}>
-          {getEntityLabel(
-            entity,
-            <span style={{ color: '#999' }}>No value {configuration.allowEditing ? '(click to edit)' : null}</span>
-          )}
-        </DocumentPreview>
+        {documentPreview}
       </RoundedCard>
     );
   }
 
   return (
     <InputAsCard key={entity.id} onClick={chooseEntity}>
-      {isModified && <ModifiedStatus />}
-      <DocumentPreview entity={entity}>
-        {getEntityLabel(
-          entity,
-          <span style={{ color: '#999' }}>No value {configuration.allowEditing ? '(click to edit)' : null}</span>
-        )}
-      </DocumentPreview>
+      {documentPreview}
     </InputAsCard>
   );
 };

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultManagePropertiesList.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultManagePropertiesList.tsx
@@ -22,7 +22,7 @@ const InstanceComponent = styled.div`
 const InstanceRemove = styled.div`
   margin-bottom: 1.2em;
   margin-left: 0.5em;
-  align-self: flex-end;
+  align-self: center;
 `;
 
 const AddNewInstance = styled.button`

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/RevisionProviderWithFeatures.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/RevisionProviderWithFeatures.tsx
@@ -33,7 +33,7 @@ export const RevisionProviderWithFeatures: React.FC<{
 }> = ({ slotConfig, children, revision, captureModel, excludeStructures, initialRevision, features }) => {
   const {
     autoSelectingRevision = true,
-    autosave = true,
+    autosave = false,
     revisionEditMode = true,
     directEdit = false,
     preventMultiple = false,

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/features/AutoSelectDefineRegion.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/features/AutoSelectDefineRegion.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect } from 'react';
 import { Revisions } from '../../editor/stores/revisions/index';
 import { isEntity } from '../../helpers/is-entity';
+import { resolveSelector } from '../../helpers/resolve-selector';
 
 export const AutoSelectDefineRegion: React.FC = () => {
+  const revisionId = Revisions.useStoreState(s => s.currentRevisionId);
   const revisionSubtreeField = Revisions.useStoreState(s => s.revisionSubtreeField);
   const revisionSubtree = Revisions.useStoreState(s => s.revisionSubtree);
   const chooseSelector = Revisions.useStoreActions(a => a.chooseSelector);
@@ -10,11 +12,14 @@ export const AutoSelectDefineRegion: React.FC = () => {
 
   useEffect(() => {
     if (!currentSelectorId && revisionSubtree && !revisionSubtreeField && isEntity(revisionSubtree)) {
-      if (revisionSubtree.selector && !revisionSubtree.selector.state) {
-        chooseSelector({ selectorId: revisionSubtree.selector.id });
+      if (revisionSubtree.selector) {
+        const revised = resolveSelector(revisionSubtree.selector, revisionId);
+        if (revised && !revised.state) {
+          chooseSelector({ selectorId: revisionSubtree.selector.id });
+        }
       }
     }
-  }, [chooseSelector, currentSelectorId, revisionSubtree, revisionSubtreeField]);
+  }, [revisionId, chooseSelector, currentSelectorId, revisionSubtree, revisionSubtreeField]);
 
   return null;
 };

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/features/AutosaveRevision.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/features/AutosaveRevision.tsx
@@ -14,7 +14,7 @@ export const AutosaveRevision: React.FC<{ minutes?: number }> = ({ minutes = 2 }
 
   const [autosaveRevision] = useMutation(async () => {
     if (!currentRevision) {
-      throw new Error(t('Unable to save your submission'));
+      return;
     }
 
     try {

--- a/services/madoc-ts/src/frontend/shared/capture-models/plugin-api/hooks/use-selector.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/plugin-api/hooks/use-selector.ts
@@ -7,6 +7,7 @@ export function useSelector<T extends BaseSelector>(
   customOptions: {
     updateSelector?: any;
     selectorPreview?: any;
+    clearSelector?: any;
     updateSelectorPreview?: (value: any) => void;
     readOnly?: boolean;
     defaultState?: any;

--- a/services/madoc-ts/src/frontend/shared/capture-models/plugin-api/hooks/use-selectors.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/plugin-api/hooks/use-selectors.ts
@@ -12,6 +12,7 @@ export function useSelectors<T extends BaseSelector>(
     readOnly?: boolean;
     isTopLevel?: boolean;
     isAdjacent?: boolean;
+    clearSelector?: any;
     hidden?: boolean;
     defaultState?: any;
     onClick?: (selector: T & InjectedSelectorProps<T['state']>) => void;
@@ -21,6 +22,7 @@ export function useSelectors<T extends BaseSelector>(
     updateSelector = null,
     selectorPreview = null,
     updateSelectorPreview,
+    clearSelector,
     readOnly = false,
     defaultState = null,
     isTopLevel = false,
@@ -54,6 +56,7 @@ export function useSelectors<T extends BaseSelector>(
         updateSelectorPreview,
         selectorPreview,
         updateSelector,
+        clearSelector,
         isTopLevel,
         isAdjacent,
         onClick,

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -588,6 +588,7 @@
   "choose": "choose",
   "collections": "collections",
   "completed": "completed",
+  "confirm": "confirm",
   "crowdsourcing-canvas-task": "crowdsourcing-canvas-task",
   "crowdsourcing-manifest-task": "crowdsourcing-manifest-task",
   "crowdsourcing-review": "crowdsourcing-review",


### PR DESCRIPTION
- Fixed default selected field "type" - it is now "text-field" making models quicker to create
- Fixed issue where you could not de-select an entity selector
- Fixed auto-selecting the "define" region when using editing an existing region
- Added "tiny" variation of image wrapper [dev]
- Added preview for entity lists using selector if it's available
- Added "confirm" to deselect or confirm the current selector
- Removed auto-save by default, causing errors and no immediate feedback to the user