### PR TITLE
Feature/view canvas grid as list

### DIFF
--- a/services/madoc-ts/src/frontend/shared/atoms/ImageGrid.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/ImageGrid.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import { ImageStripBox } from './ImageStrip';
 
 const getSize = (props: any) => {
   switch (props.$size) {
@@ -27,6 +28,31 @@ export const ImageGrid = styled.div<{
 
   > * {
     max-width: calc(${getSize} * 1.5);
+  }
+
+  &[data-view-list='true'] {
+    padding: 0 5em;
+    grid-template-columns: repeat(1, minmax(${getSize}, 1fr));
+    a {
+      width: 100%;
+      display: flex;
+    }
+    > * {
+      max-width: 100%;
+    }
+    ${ImageStripBox} {
+      width: 100%;
+      display: flex;
+      &:hover {
+        border: 2px dotted;
+      }
+      h5 {
+        padding-left: 1em;
+      }
+      img {
+        max-width: 150px;
+      }
+    }
   }
 `;
 

--- a/services/madoc-ts/src/frontend/shared/atoms/ImageStrip.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/ImageStrip.tsx
@@ -22,6 +22,7 @@ export const ImageStripBox = styled.div<{
 
   &:hover {
     background: rgba(0, 0, 0, 0.1);
+    filter: brightness(90%);
     cursor: pointer;
   }
 `;

--- a/services/madoc-ts/src/frontend/shared/atoms/ImageStrip.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/ImageStrip.tsx
@@ -32,6 +32,7 @@ export const ImageStrip = styled.div`
           auto-fill,
           200px
   );
+  grid-row-gap: 1em;
   overflow-x: auto;
   text-decoration: none;
   justify-content: space-evenly;

--- a/services/madoc-ts/src/frontend/shared/atoms/ObjectContainer.tsx
+++ b/services/madoc-ts/src/frontend/shared/atoms/ObjectContainer.tsx
@@ -7,7 +7,7 @@ export const ObjectContainer = styled.div<{
   $color?: string;
   $radius?: number;
 }>`
-  background: ${props => props.$background || '#eee'};
+  background: ${props => props.$background || 'inherit'};
   color: ${props => props.$color || 'inherit'};
   margin-bottom: 20px;
   padding: 20px 20px 40px;

--- a/services/madoc-ts/src/frontend/shared/components/FeaturedItem.tsx
+++ b/services/madoc-ts/src/frontend/shared/components/FeaturedItem.tsx
@@ -43,7 +43,6 @@ const FeatureCard = styled.div`
   :hover {
     border-style: dotted;
     cursor: pointer;
-    background: rgba(0, 0, 0, 0.1);
     filter: brightness(90%);
   }
 `;
@@ -84,7 +83,7 @@ export function FeaturedItem(props: FeaturedItemProps) {
           {items.map(item => {
             return (
               item && (
-                <Link
+                <Link key={item.id}
                   to={createLink({
                     canvasId: item.id,
                     manifestId: manifestId,

--- a/services/madoc-ts/src/frontend/shared/components/FeaturedItem.tsx
+++ b/services/madoc-ts/src/frontend/shared/components/FeaturedItem.tsx
@@ -36,12 +36,15 @@ const FeatureCard = styled.div`
   display: flex;
   border: 1px solid;
   margin: 1em;
-  
+
   h5 {
     color: inherit;
   }
   :hover {
     border-style: dotted;
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.1);
+    filter: brightness(90%);
   }
 `;
 
@@ -94,12 +97,7 @@ export function FeaturedItem(props: FeaturedItemProps) {
                       color: props.textColor,
                     }}
                   >
-                    <ImageStripBox
-                      $size="small"
-                      $bgColor={props.cardBackground}
-                      $color={props.textColor}
-                      $border={props.cardBorder}
-                    >
+                    <ImageStripBox $size="small" $bgColor={props.cardBackground}>
                       <CroppedImage $size="small" $covered={props.imageStyle === 'covered'}>
                         {item.thumbnail ? (
                           <img alt={createLocaleString(item.label, t('item thumbnail'))} src={item.thumbnail[0].id} />

--- a/services/madoc-ts/src/frontend/site/features/ManifestCanvasGrid.tsx
+++ b/services/madoc-ts/src/frontend/site/features/ManifestCanvasGrid.tsx
@@ -25,6 +25,7 @@ import { usePreventCanvasNavigation } from './PreventUsersNavigatingCanvases';
 export function ManifestCanvasGrid(props: {
   background?: string;
   popup?: boolean;
+  list?: boolean;
   font?: string;
   textColor?: string;
   canvasBorder?: string;
@@ -49,16 +50,18 @@ export function ManifestCanvasGrid(props: {
   const hideCanvasLabels = manifestOptions?.hideCanvasLabels;
   const manifest = data?.manifest;
 
-  // const bg = props.background !== undefined ? props.background : '';
-  // const _color = useAccessibleColor(bg);
-
   if (!manifest || !showNavigationContent) {
     return null;
   }
 
   const renderCanvasSnippet = (canvas: { id: number; label: InternationalString; thumbnail: string | null }) => {
     return (
-      <ImageStripBox $border={props.canvasBorder} $color={props.textColor} $bgColor={props.background}>
+      <ImageStripBox
+        data-view-list={props.list}
+        $border={props.canvasBorder}
+        $color={props.textColor}
+        $bgColor={props.background}
+      >
         <CroppedImage $covered={coveredImages || props.imageStyle === 'covered'} $rect={rectangularImages}>
           {canvas.thumbnail ? (
             <img alt={createLocaleString(canvas.label, t('Canvas thumbnail'))} src={canvas.thumbnail} />
@@ -74,7 +77,7 @@ export function ManifestCanvasGrid(props: {
 
   if (props.popup) {
     return (
-      <ImageGrid>
+      <ImageGrid data-view-list={props.list}>
         {manifest.items.map((canvas, idx) => (
           <ModalButton
             modalSize="lg"
@@ -98,7 +101,7 @@ export function ManifestCanvasGrid(props: {
   }
 
   return (
-    <ImageGrid>
+    <ImageGrid data-view-list={props.list}>
       {manifest.items.map((canvas, idx) => (
         <Link
           key={`${canvas.id}_${idx}`}
@@ -120,12 +123,14 @@ blockEditorFor(ManifestCanvasGrid, {
   defaultProps: {
     background: '',
     popup: false,
+    list: false,
     textColor: '',
     canvasBorder: '',
     imageStyle: 'fit',
   },
   editor: {
     popup: { type: 'checkbox-field', label: 'Popup', inlineLabel: 'Show canvases in popup' },
+    list: { type: 'checkbox-field', label: 'View', inlineLabel: 'Display as list' },
     background: { label: 'Card background color', type: 'color-field' },
     textColor: { label: 'Card text color', type: 'color-field' },
     canvasBorder: { label: 'Card border', type: 'color-field' },

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -679,6 +679,7 @@
   "User sites": "User sites",
   "Users": "Users",
   "Users working on this task": "Users working on this task",
+  "View": "View",
   "View all contributions": "View all contributions",
   "View and query options for search pages": "View and query options for search pages",
   "View documentation": "View documentation",


### PR DESCRIPTION
- add option to canvas grid to dissplay as list instead of grid:
<img width="1391" alt="Screenshot 2022-11-03 at 16 42 15" src="https://user-images.githubusercontent.com/52662841/199783544-eda9fd38-670b-4dbf-864b-3a094a282144.png">

- add some space inbetween grid items so looks better if background color is changed:
<img width="1555" alt="Screenshot 2022-11-03 at 16 52 49" src="https://user-images.githubusercontent.com/52662841/199785297-f9d503cd-a9ae-487b-91ce-e3090172dabf.png">
