### PR TITLE
document view shows correct fields

### DIFF
--- a/services/madoc-ts/src/frontend/shared/capture-models/_components/ViewDocument/render/render-property.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/_components/ViewDocument/render/render-property.tsx
@@ -30,7 +30,11 @@ export const renderProperty = (
 ) => {
   const label =
     fields.length > 1 && fields[0] && fields[0].pluralLabel ? fields[0].pluralLabel : fields[0] ? fields[0].label : '';
-  const filteredFields = filterRevises(fields).filter(f => {
+
+  const arrFixed: Array<typeof fields[number]> = fields;
+  const firstFilter = arrFixed.filter(item => filterRevisions.indexOf(item.revision ? item.revision : '') === -1);
+
+  const filteredFields = filterRevises(firstFilter).filter(f => {
     if (highlightRevisionChanges) {
       const revised = f.type === 'entity' || (f.revision && f.revision === highlightRevisionChanges);
       if (!revised) {

--- a/services/madoc-ts/src/frontend/site/features/CreateModelTestCase.tsx
+++ b/services/madoc-ts/src/frontend/site/features/CreateModelTestCase.tsx
@@ -197,7 +197,9 @@ export function CreateModelTestCase(props: { captureModel?: CaptureModel }) {
               <>
                 <li>
                   <strong style={{ userSelect: 'none' }}>manifest:</strong>{' '}
-                  <a href={options.target.manifestUri}>{options.target.manifestUri}</a>
+                  <a href={options.target.manifestUri} target="_blank" rel="noreferrer">
+                    {options.target.manifestUri}
+                  </a>
                 </li>
                 <li>
                   <strong style={{ userSelect: 'none' }}>canvas:</strong> {options.target.canvasUri}

--- a/services/madoc-ts/stories/capture-models/interactions/CaptureModelTestHarness.tsx
+++ b/services/madoc-ts/stories/capture-models/interactions/CaptureModelTestHarness.tsx
@@ -101,6 +101,12 @@ export function CaptureModelTestHarness(props: CaptureModelTestHarnessProps) {
       : null;
   }, [captureModel, revision]);
 
+  const incompleteRevisions = (captureModel.revisions || [])
+    .filter(rev => {
+      return !rev.approved;
+    })
+    .map(rev => rev.id);
+
   const revisionJson = (
     <>
       <pre data-testid="revision-json">{JSON.stringify(allRevisionsWithStructures, null, 2)}</pre>
@@ -186,7 +192,7 @@ export function CaptureModelTestHarness(props: CaptureModelTestHarnessProps) {
                     key={JSON.stringify(captureModel.document)}
                     hideEmpty
                     document={captureModel.document}
-                    highlightRevisionChanges={revision}
+                    filterRevisions={incompleteRevisions}
                   />
                 </DynamicVaultContext>
               ) : null}


### PR DESCRIPTION
changed` highlightRevisionChanges={revision}` to `filterRevisions={incompleteRevisions}` for the document tab

then made sure it filtered that out in `render-proterty`  before `filter-revise` becasue filter revise will return the most recent revision even if its not approved.  