### PR TITLE
Hotfix/nested entity bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ supports a wider range of IIIF resources as a result.
 * Fixed bug with "Start contributing" returning invalid results
 * Fixed bug with "Max contributors" if user had already started working
 * Fixed "Maximise window" to avoid cutting off the top section of the header
+* Fixed firefox bug where "Define window" button was disabled if selector required
+* Fixed Annotation styled hidden by default 
+* Fixed some fields showing in submision if empty 
+
 
 ### Added
 

--- a/services/madoc-ts/src/frontend/shared/capture-models/AnnotationStyleContext.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/AnnotationStyleContext.tsx
@@ -42,10 +42,10 @@ export function getDefaultAnnotationStyles(): AnnotationStyles['theme'] {
       },
     },
     contributedDocument: {
-      hidden: true,
-      borderWidth: '0px',
-      borderColor: 'rgba(0,0,0,0)',
-      backgroundColor: 'rgba(0,0,0,0)',
+      hidden: false,
+      borderWidth: '1px',
+      borderColor: 'rgba(87,36,203,0.5)',
+      backgroundColor: 'rgba(87,36,203,0.2)',
     },
     submissions: {
       hidden: false,

--- a/services/madoc-ts/src/frontend/shared/capture-models/_components/ViewDocument/components/ViewSelector.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/_components/ViewDocument/components/ViewSelector.tsx
@@ -28,6 +28,12 @@ export const ViewSelector: React.FC<{
         setImage(cropped);
       }
     }
+    if (selector && selector.revisedBy && selector.revisedBy[0].state) {
+      const cropped = croppedRegion(selector.revisedBy[0].state);
+      if (cropped) {
+        setImage(cropped);
+      }
+    }
   }, [croppedRegion, selector, service]);
 
   if (!image) {

--- a/services/madoc-ts/src/frontend/shared/capture-models/_components/ViewDocument/components/ViewSelector.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/_components/ViewDocument/components/ViewSelector.tsx
@@ -28,7 +28,7 @@ export const ViewSelector: React.FC<{
         setImage(cropped);
       }
     }
-    if (selector && selector.revisedBy && selector.revisedBy[0].state) {
+    if (selector && selector.revisedBy && selector.revisedBy[0]) {
       const cropped = croppedRegion(selector.revisedBy[0].state);
       if (cropped) {
         setImage(cropped);

--- a/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultFieldInstance.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/new/components/DefaultFieldInstance.tsx
@@ -18,7 +18,7 @@ export const DefaultFieldInstance: React.FC<{
   const immutable = immutableFields.indexOf(property) !== -1;
   const [selector, { isBlockingForm: disableForm }] = useResolvedSelector(field);
 
-  useEffect(() => {
+    useEffect(() => {
     if (selector) {
       if (isHighlighted) {
         return helper.highlight(selector.id);
@@ -47,7 +47,6 @@ export const DefaultFieldInstance: React.FC<{
 
   return (
     <FieldSet
-      disabled={disableForm}
       onFocus={onFocus}
       onBlur={onBlur}
       data-field-id={field.id}
@@ -56,6 +55,7 @@ export const DefaultFieldInstance: React.FC<{
       data-aria-description={field.description}
     >
       <FieldInstance
+        disabled={disableForm}
         key={field.revises ? field.revises : field.id}
         field={field}
         property={property}

--- a/services/madoc-ts/src/frontend/shared/capture-models/utility/is-field-list-empty.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/utility/is-field-list-empty.ts
@@ -15,7 +15,7 @@ export const isEmptyFieldList = (fields: BaseField[]) => {
     }
 
     if (field.selector) {
-      if (field.selector.revisedBy && field.selector.revisedBy.length) {
+      if ((field.selector.revisedBy && field.selector.revisedBy.length) || field.selector.state) {
         return false;
       }
     }

--- a/services/madoc-ts/src/frontend/shared/capture-models/utility/is-field-list-empty.ts
+++ b/services/madoc-ts/src/frontend/shared/capture-models/utility/is-field-list-empty.ts
@@ -8,8 +8,16 @@ export const isEmptyFieldList = (fields: BaseField[]) => {
   for (const field of fields) {
     if (field.value) {
       // Hack. We need an "isEmpty" on the field definitions I think.
+      if (field.type === 'international-field') {
+        const intValues = Object.values(field.value);
+        return intValues.every((s: any) => s[0] === '');
+      }
+
       if (field.type === 'border-field') {
         return field.value.size === 0;
+      }
+      if (field.type === 'checkbox-list-field') {
+        return Object.keys(field.value).length < 1;
       }
       return false;
     }

--- a/services/madoc-ts/src/frontend/site/features/ProjectContributors.tsx
+++ b/services/madoc-ts/src/frontend/site/features/ProjectContributors.tsx
@@ -51,7 +51,7 @@ export function ProjectContributors(props: ProjectContributors) {
 
   const [, isBot] = useBots();
 
-  if (!data || !contributors?.length) return <p>no</p>;
+  if (!data || !contributors?.length) return <p>No contributors yet</p>;
 
   return (
     <ContributorsWrapper>

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -227,7 +227,6 @@
   "Default layout": "Default layout",
   "Default project configuration": "Default project configuration",
   "Define region": "Define region",
-  "Define region hola": "Define region hola",
   "Delete": "Delete",
   "Delete Manifest": "Delete Manifest",
   "Delete Project": "Delete Project",

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -227,6 +227,7 @@
   "Default layout": "Default layout",
   "Default project configuration": "Default project configuration",
   "Define region": "Define region",
+  "Define region hola": "Define region hola",
   "Delete": "Delete",
   "Delete Manifest": "Delete Manifest",
   "Delete Project": "Delete Project",


### PR DESCRIPTION
**Fixed**
- ProjectContributors showing 'no' if no contributors 
- Firefox "Define Region" disabled if textfield is disabled 
- Entities without field values showing "No document" 
- Entities sometimes not showing box preview 
- Checkbox-list-feild and international-field always passing isEmpty 
- Annotation styles for contirbutedDocument and submissions are always hidden 