### PR TITLE
NS-15 migration of completions from Madoc 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ supports a wider range of IIIF resources as a result.
 * Added secondary view for "X hours ago" to show the date and time on click (browser preference)
 * Added "Generate PDF" option for manifests using PDiiif
 * Added small indication under choices in the capture model UI with number of previous submissions
+* Added new auto-complete endpoints migrated from Madoc 1.x
+  * [searchFAST](http://fast.oclc.org/searchfast/)
+  * [WikiData](https://www.wikidata.org)
 
 ### Changed
 

--- a/services/madoc-ts/src/app.ts
+++ b/services/madoc-ts/src/app.ts
@@ -7,6 +7,7 @@ import Ajv from 'ajv';
 import { strategies } from './auth';
 import { checkExpiredManifests } from './cron/check-expired-manifests';
 import './frontend/shared/plugins/globals';
+import { CompletionsExtension } from './extensions/completions/extension';
 import { createPluginManager } from './middleware/create-plugin-manager';
 import { disposeApis } from './middleware/dispose-apis';
 import { errorHandler } from './middleware/error-handler';
@@ -52,6 +53,7 @@ export async function createApp(config: ExternalConfig, env: EnvConfig) {
   app.context.externalConfig = config;
   app.context.routes = router;
   app.context.cron = new CronJobs();
+  app.context.completions = new CompletionsExtension();
 
   awaitProperty(createPluginManager(pool), manager => {
     app.context.pluginManager = manager;

--- a/services/madoc-ts/src/extensions/completions/extension.ts
+++ b/services/madoc-ts/src/extensions/completions/extension.ts
@@ -1,0 +1,59 @@
+import { Request } from 'koa';
+import { CompletionItem } from '../../frontend/shared/capture-models/editor/input-types/AutocompleteField/AutocompleteField';
+import { ApiClientWithoutExtensions } from '../../gateway/api';
+import { RequestError } from '../../utility/errors/request-error';
+import { wikidataSource } from './sources/wikidata-source';
+import { worldcatFastSource } from './sources/worldcat-fast-source';
+import { CompletionSource } from './types';
+
+export class CompletionsExtension {
+  //
+  sources: Record<string, CompletionSource> = {};
+  constructor() {
+    // Sources will just be hard-coded for now.
+    this.sources[wikidataSource.name] = wikidataSource;
+    this.sources[worldcatFastSource.name] = worldcatFastSource;
+  }
+
+  async doCompletion(
+    type: string,
+    {
+      request,
+      userId,
+      api,
+      siteId,
+      projectId,
+      language,
+    }: {
+      request: Request;
+      api: ApiClientWithoutExtensions;
+      siteId: number;
+      userId?: number;
+      projectId?: number | null;
+      language: string;
+    }
+  ): Promise<{ completions: CompletionItem[] }> {
+    const source = this.sources[type];
+
+    if (!source) {
+      throw new RequestError(`Completion ${type} not found`);
+    }
+
+    const languages = request.acceptsLanguages() || [];
+    const { q, page, ...other } = request.query;
+
+    const completions = await source.doCompletion(
+      {
+        query: q,
+        language: language || (Array.isArray(languages) ? languages[0] || 'en' : 'en'),
+        other: other,
+        page: page ? ~~parseFloat(page) : 1,
+      },
+      { userId, api, siteId, projectId }
+    );
+
+    return {
+      completions,
+    };
+  }
+}

--- a/services/madoc-ts/src/extensions/completions/sources/wikidata-source.ts
+++ b/services/madoc-ts/src/extensions/completions/sources/wikidata-source.ts
@@ -1,0 +1,63 @@
+import { stringify } from 'query-string';
+import { CompletionItem } from '../../../frontend/shared/capture-models/editor/input-types/AutocompleteField/AutocompleteField';
+import { RequestError } from '../../../utility/errors/request-error';
+import { CompletionSource } from '../types';
+
+export const wikidataSource: CompletionSource = {
+  name: 'wikidata',
+  async doCompletion(options) {
+    // Example:
+    // https://www.wikidata.org/w/api.php?search=car&format=json&action=wbsearchentities&language=en&uselang=en&limit=5
+    const resp = await fetch(
+      `https://www.wikidata.org/w/api.php?${stringify({
+        search: options.query,
+        format: 'json',
+        action: 'wbsearchentities',
+        language: options.language || 'en',
+        uselang: options.language || 'en',
+        limit: 10,
+      })}`
+    );
+
+    if (!resp.ok) {
+      throw new RequestError(`Unknown error`);
+    }
+
+    const body = (await resp.json()) as WikiDataResponse;
+
+    return body.search
+      .filter(item => {
+        return item.repository === 'wikidata';
+      })
+      .map(result => {
+        return {
+          label: result.display.label.value,
+          description: result.display.description.value,
+          resource_class: result.id,
+          language: result.display.label.language || 'en',
+          uri: result.concepturi,
+        } as CompletionItem;
+      });
+  },
+};
+
+interface WikiDataResponse {
+  search: Array<{
+    id: string;
+    aliases: string[];
+    description: string;
+    concepturi: string;
+    title: string;
+    pageid: number;
+    repository: string;
+    match: { type: string; language: string; text: string };
+    url: string;
+    display: {
+      label: { value: string; language: string };
+      description: { value: string; language: string };
+    };
+  }>;
+  'search-continue': 5;
+  success: number;
+  searchinfo: { search: string };
+}

--- a/services/madoc-ts/src/extensions/completions/sources/worldcat-fast-source.ts
+++ b/services/madoc-ts/src/extensions/completions/sources/worldcat-fast-source.ts
@@ -1,0 +1,73 @@
+import { stringify } from 'query-string';
+import { CompletionItem } from '../../../frontend/shared/capture-models/editor/input-types/AutocompleteField/AutocompleteField';
+import { RequestError } from '../../../utility/errors/request-error';
+import { CompletionSource } from '../types';
+
+const FAST_URI = 'http://fast.oclc.org/searchfast/fastsuggest';
+const FAST_REPRESENTATION = 'http://id.worldcat.org/fast/';
+
+export const worldcatFastSource: CompletionSource = {
+  name: 'worldcat-fast',
+  async doCompletion(options, context) {
+    const query = {
+      query: options.query,
+      queryIndex: 'suggestall',
+      suggest: 'autoSubject',
+      queryReturn: 'auth type suggestall tag idroot',
+      rows: 20,
+    };
+    const resp = await fetch(`${FAST_URI}?${stringify(query)}`);
+    if (!resp.ok) {
+      throw new RequestError(`Unable to parse response from FAST endpoint`);
+    }
+
+    const body = (await resp.json()) as FastResponse;
+
+    return body.response.docs
+      .filter(doc => doc.type === 'auth')
+      .map(doc => {
+        return {
+          uri: FAST_REPRESENTATION + doc.idroot,
+          label: doc.auth,
+          tag: getTagName(doc.tag),
+        } as CompletionItem;
+      });
+  },
+};
+
+interface FastResponse {
+  response: {
+    numFound: number;
+    start: number;
+    docs: Array<{
+      idroot: string;
+      tag: number;
+      type: string;
+      auth: string;
+      suggestall: string[];
+    }>;
+  };
+}
+
+function getTagName(tag: number) {
+  switch (tag) {
+    case 100:
+      return 'Personal Name';
+    case 110:
+      return 'Corporate Name';
+    case 111:
+      return 'Event';
+    case 130:
+      return 'Uniform Title';
+    case 148:
+      return 'Period';
+    case 150:
+      return 'Topic';
+    case 151:
+      return 'Geographic';
+    case 155:
+      return 'Form/Genre';
+    default:
+      return 'unknown';
+  }
+}

--- a/services/madoc-ts/src/extensions/completions/types.ts
+++ b/services/madoc-ts/src/extensions/completions/types.ts
@@ -1,0 +1,17 @@
+import { CompletionItem } from '../../frontend/shared/capture-models/editor/input-types/AutocompleteField/AutocompleteField';
+import { ApiClientWithoutExtensions } from '../../gateway/api';
+
+export interface CompletionSource {
+  name: string;
+  doCompletion(
+    options: CompletionSourceRequest,
+    context: { api: ApiClientWithoutExtensions; siteId: number; userId?: number; projectId?: number | null }
+  ): Promise<CompletionItem[]>;
+}
+
+export interface CompletionSourceRequest {
+  query: string;
+  language?: string;
+  page?: number;
+  other?: Record<string, string>;
+}

--- a/services/madoc-ts/src/frontend/shared/capture-models/editor/input-types/AutocompleteField/AutocompleteField.tsx
+++ b/services/madoc-ts/src/frontend/shared/capture-models/editor/input-types/AutocompleteField/AutocompleteField.tsx
@@ -25,6 +25,11 @@ export type CompletionItem = {
   label: string | InternationalString;
   resource_class?: string;
   score?: number;
+
+  // Future fields to use.
+  description?: string | InternationalString;
+
+  language?: string;
 };
 
 function renderOptionLabel(option: CompletionItem) {

--- a/services/madoc-ts/src/router.ts
+++ b/services/madoc-ts/src/router.ts
@@ -86,6 +86,7 @@ import { updateInvitation } from './routes/manage-site/update-invitation';
 import { updateSiteDetails } from './routes/manage-site/update-site-details';
 import { updateUserSiteRole } from './routes/manage-site/update-user-site-role';
 import { getAllProjectNotes } from './routes/projects/get-all-project-notes';
+import { siteCompletions } from './routes/site/site-completions';
 import { siteDetails } from './routes/site/site-details';
 import { deleteManifestSummary } from './routes/iiif/manifests/delete-manifest-summary';
 import { siteManifestBuild } from './routes/site/site-manifest-build';
@@ -610,6 +611,7 @@ export const router = new TypedRouter({
     siteCanvasTasks,
   ],
   'site-configuration': [TypedRouter.GET, '/s/:slug/madoc/api/configuration', siteConfiguration],
+  'site-completion': [TypedRouter.GET, '/s/:slug/madoc/api/completions/:type', siteCompletions],
   'site-model-configuration': [TypedRouter.GET, '/s/:slug/madoc/api/configuration/model', siteModelConfiguration],
   'site-page-navigation': [TypedRouter.GET, '/s/:slug/madoc/api/pages/navigation/:paths*', sitePageNavigation],
   'site-facet-configuration': [

--- a/services/madoc-ts/src/routes/site/site-completions.ts
+++ b/services/madoc-ts/src/routes/site/site-completions.ts
@@ -1,0 +1,23 @@
+import { getProject } from '../../database/queries/project-queries';
+import { RouteMiddleware } from '../../types/route-middleware';
+import { parseProjectId } from '../../utility/parse-project-id';
+
+export const siteCompletions: RouteMiddleware<{ type: string }> = async context => {
+  const lng = context.cookies.get('i18next');
+  const { site, siteApi, authenticatedUser } = context.state;
+
+  const completionType = context.params.type;
+  const parsedId = context.query.project_id ? parseProjectId(context.query.project_id) : null;
+  const project = parsedId ? await context.connection.one(getProject(parsedId, site.id)) : null;
+  const projectId = project ? project.id : null;
+
+  context.response.body = await context.completions.doCompletion(completionType, {
+    request: context.request,
+    siteId: site.id,
+    api: siteApi,
+    userId: authenticatedUser?.id,
+    projectId,
+    language: lng || 'en',
+  });
+  context.response.status = 200;
+};

--- a/services/madoc-ts/src/types/application-context.ts
+++ b/services/madoc-ts/src/types/application-context.ts
@@ -1,4 +1,5 @@
 import { i18n } from 'i18next';
+import { CompletionsExtension } from '../extensions/completions/extension';
 import { PluginManager } from '../frontend/shared/plugins/plugin-manager';
 import { ChangeDiscoveryRepository } from '../activity-streams/change-discovery-repository';
 import { ApiClient } from '../gateway/api';
@@ -41,6 +42,8 @@ declare module 'koa' {
     siteManager: SiteUserRepository;
     pluginManager: PluginManager;
     cron: CronJobs;
+
+    completions: CompletionsExtension;
     ajv: Ajv;
     staticPage?: string | ((token: string) => Promise<string | undefined>) | ((token: string) => undefined | string);
     disposableApis: ApiClient[];


### PR DESCRIPTION
Migrated from:
https://github.com/digirati-co-uk/madoc-platform/blob/1.2.17/repos/auto-complete/src/Controller/CompletionController.php#L38-L69 With related bits for Fast tagging here:
https://github.com/digirati-co-uk/madoc-platform/blob/1.2.17/repos/auto-complete/src/Completion/Contributors/FastResourceCompletionContributor.php And wikidata here:
https://github.com/digirati-co-uk/madoc-platform/blob/1.2.17/repos/auto-complete/src/Completion/Contributors/WikiDataResourceCompletionContributor.php