### PR TITLE
MAD-1152 changed to use local name if available

### DIFF
--- a/services/madoc-ts/src/frontend/shared/utility/create-server-renderer.tsx
+++ b/services/madoc-ts/src/frontend/shared/utility/create-server-renderer.tsx
@@ -239,7 +239,11 @@ export function createServerRenderer(
 
     const dehydratedState = dehydrate(prefetchCache);
     const mapLocalCodes = (ln: string) => {
-      const label = localeCodes.getByTag(ln).name;
+      let label = localeCodes.getByTag(ln).local || localeCodes.getByTag(ln).name;
+      if (label === 'Welsh') {
+        label = 'Cymraeg';
+      }
+
       return { label: label, code: ln };
     };
     const supportedLocales = siteLocales.localisations.map(ln => {


### PR DESCRIPTION
![image](https://github.com/digirati-co-uk/madoc-platform/assets/8266711/c9f457ca-21a8-4d3a-bc2b-70f277a95158)
