### PR TITLE
add allow same origin on embeded item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed block editor button 'saved' instead of 'save' (MAD-1475)
 - Fixed marking canvas as incomplete not marking manifest as incomplete (MAD-1516)
+- Fixed CORS errors in embed item block
 
 ## [v2.2.7](https://github.com/digirati-co-uk/madoc-platform/compare/v2.2.6...v2.2.7)
 

--- a/services/madoc-ts/src/frontend/site/blocks/EmbedItem.tsx
+++ b/services/madoc-ts/src/frontend/site/blocks/EmbedItem.tsx
@@ -14,7 +14,14 @@ export const EmbedItem: React.FC<{
 }> = ({ link, height, width }) => {
   return (
     <EmbedWrapper>
-      <iframe src={link} height={height} width={width} loading="lazy" referrerPolicy="no-referrer" sandbox="allow-scripts" />
+      <iframe
+        src={link}
+        height={height}
+        width={width}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        sandbox="allow-scripts allow-same-origin"
+      />
     </EmbedWrapper>
   );
 };

--- a/services/madoc-ts/src/frontend/site/blocks/EmbedItem.tsx
+++ b/services/madoc-ts/src/frontend/site/blocks/EmbedItem.tsx
@@ -37,7 +37,7 @@ blockEditorFor(EmbedItem, {
     width: '400',
   },
   editor: {
-    link: { type: 'text-field', label: 'src or link' },
+    link: { type: 'text-field', label: 'src or link', description: 'paste an embed src/link without quotes' },
     height: { type: 'text-field', label: 'height (px)' },
     width: { type: 'text-field', label: 'width (px)' },
   },

--- a/services/madoc-ts/translations/en/madoc.json
+++ b/services/madoc-ts/translations/en/madoc.json
@@ -1190,6 +1190,7 @@
   "secondButton": "secondButton",
   "secondButtonLink": "secondButtonLink",
   "size": "size",
+  "some help text": "some help text",
   "src or link": "src or link",
   "summary": "summary",
   "switch to the main revision": "switch to the main revision",


### PR DESCRIPTION
<img width="1250" alt="Screenshot 2025-02-20 at 11 04 14" src="https://github.com/user-attachments/assets/1f5d90b1-8297-4af7-93b0-ee14f08327c5" />


<img width="908" alt="Screenshot 2025-02-20 at 11 04 19" src="https://github.com/user-attachments/assets/4a554127-be4f-42c3-8b83-4aa0f3cb6a8f" />

Now works with both youtube and awesomescreenshots 
